### PR TITLE
MR-170: Add additional testing gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,10 @@ group :development, :test do
   gem 'solr_wrapper', '~> 2.0.0'
   gem 'fcrepo_wrapper'
   gem 'rspec-rails'
+  gem 'rspec-its'
+  gem 'rails-controller-testing'
+  gem 'factory_bot_rails', '~> 4.8'
+  gem 'webmock'
 end
 
 group :production do

--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,6 @@ group :production do
 end
 
 group :development, :test do
-  gem 'sqlite3'
   gem 'puma', '~> 3.7'
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile
+++ b/Gemfile
@@ -6,73 +6,52 @@ git_source(:github) do |repo_name|
 end
 
 gem 'rails', '~> 5.1.4'
-# Use SCSS for stylesheets
+# Use postgresql for all environments, not just production
+gem 'pg'
 gem 'sass-rails', '~> 5.0'
-# Use Uglifier as compressor for JavaScript assets
 gem 'uglifier', '>= 1.3.0'
-# See https://github.com/rails/execjs#readme for more supported runtimes
-# gem 'therubyracer', platforms: :ruby
-
-# Use CoffeeScript for .coffee assets and views
 gem 'coffee-rails', '~> 4.2'
-# Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks
 gem 'turbolinks', '~> 5'
-# Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.5'
+gem 'figaro'
 # Use Redis adapter to run Action Cable in production
 # gem 'redis', '~> 3.0'
-# Use ActiveModel has_secure_password
-# gem 'bcrypt', '~> 3.1.7'
+gem 'rsolr', '>= 1.0'
+gem 'jquery-rails'
+gem 'devise'
+gem 'devise-guests', '~> 0.6'
 
-# Use Capistrano for deployment
-# gem 'capistrano-rails', group: :development
+gem 'riiif', '~> 1.1'
+
+gem 'hyrax', '2.1.0'
+gem 'hydra-role-management'
 
 gem 'resque'
 gem 'resque-pool'
 gem 'resque-web', require: 'resque_web'
-gem 'figaro'
 
-group :production do
-  gem 'passenger'
-  gem 'therubyracer', platforms: :ruby
-end
-
-group :development, :test do
-  gem 'puma', '~> 3.7'
-  # Call 'byebug' anywhere in the code to stop execution and get a debugger console
-  gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
-  # Adds support for Capybara system testing and selenium driver
-  gem 'capybara', '~> 2.13'
-  gem 'selenium-webdriver'
-end
+# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
+gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 group :development do
   # Access an IRB console on exception pages or by using <%= console %> anywhere in the code.
   gem 'web-console', '>= 3.3.0'
   gem 'listen', '>= 3.0.5', '< 3.2'
-  # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
 end
 
-# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
-
-gem 'hyrax', '2.1.0'
 group :development, :test do
+  gem 'puma', '~> 3.7'
+  gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
+  gem 'capybara', '~> 2.13'
+  gem 'selenium-webdriver'
   gem 'solr_wrapper', '~> 2.0.0'
-end
-
-gem 'rsolr', '>= 1.0'
-gem 'jquery-rails'
-gem 'devise'
-gem 'devise-guests', '~> 0.6'
-group :development, :test do
   gem 'fcrepo_wrapper'
   gem 'rspec-rails'
 end
 
-gem 'riiif', '~> 1.1'
-gem 'pg'
-
-gem 'hydra-role-management'
+group :production do
+  gem 'passenger'
+  gem 'therubyracer', platforms: :ruby
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -154,6 +154,8 @@ GEM
     commonjs (0.2.7)
     concurrent-ruby (1.0.5)
     connection_pool (2.2.2)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     crass (1.0.4)
     daemons (1.2.6)
     declarative (0.0.10)
@@ -211,6 +213,11 @@ GEM
       nokogiri (>= 1.4.3)
     erubi (1.7.1)
     execjs (2.7.0)
+    factory_bot (4.10.0)
+      activesupport (>= 3.0.0)
+    factory_bot_rails (4.10.0)
+      factory_bot (~> 4.10.0)
+      railties (>= 3.0.0)
     faraday (0.12.2)
       multipart-post (>= 1.2, < 3)
     faraday-encoding (0.0.4)
@@ -254,6 +261,7 @@ GEM
       tilt
     hamster (3.0.0)
       concurrent-ruby (~> 1.0)
+    hashdiff (0.3.7)
     hiredis (0.6.1)
     htmlentities (4.3.4)
     http_logger (0.5.1)
@@ -539,6 +547,10 @@ GEM
       bundler (>= 1.3.0)
       railties (= 5.1.6)
       sprockets-rails (>= 2.0.0)
+    rails-controller-testing (1.0.2)
+      actionpack (~> 5.x, >= 5.0.1)
+      actionview (~> 5.x, >= 5.0.1)
+      activesupport (~> 5.x)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
@@ -652,6 +664,9 @@ GEM
     rspec-expectations (3.7.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.7.0)
+    rspec-its (1.2.0)
+      rspec-core (>= 3.0.0)
+      rspec-expectations (>= 3.0.0)
     rspec-mocks (3.7.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.7.0)
@@ -672,6 +687,7 @@ GEM
     ruby-progressbar (1.9.0)
     ruby_dep (1.5.0)
     rubyzip (1.2.1)
+    safe_yaml (1.0.4)
     samvera-nesting_indexer (2.0.0)
       dry-equalizer
     sass (3.5.6)
@@ -753,7 +769,6 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    sqlite3 (1.3.13)
     stomp (1.4.4)
     sxp (1.0.1)
       rdf (>= 2.2, < 4.0)
@@ -792,6 +807,10 @@ GEM
       activemodel (>= 5.0)
       bindex (>= 0.4.0)
       railties (>= 5.0)
+    webmock (3.4.2)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
@@ -808,6 +827,7 @@ DEPENDENCIES
   coffee-rails (~> 4.2)
   devise
   devise-guests (~> 0.6)
+  factory_bot_rails (~> 4.8)
   fcrepo_wrapper
   figaro
   hydra-role-management
@@ -819,23 +839,25 @@ DEPENDENCIES
   pg
   puma (~> 3.7)
   rails (~> 5.1.4)
+  rails-controller-testing
   resque
   resque-pool
   resque-web
   riiif (~> 1.1)
   rsolr (>= 1.0)
+  rspec-its
   rspec-rails
   sass-rails (~> 5.0)
   selenium-webdriver
   solr_wrapper (~> 2.0.0)
   spring
   spring-watcher-listen (~> 2.0.0)
-  sqlite3
   therubyracer
   turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
+  webmock
 
 BUNDLED WITH
    1.16.2


### PR DESCRIPTION
- Updated Gemfile structure (moved gems that apply to all environments to the top; combined multiple "development,test" groups into one, removed some default comments to streamline)

- Installed additional gems:
      gem 'rspec-its'
      gem 'rails-controller-testing'
      gem 'factory_bot_rails', '~> 4.8'
      gem 'webmock'