### PR TITLE
Configure log rotation in production environment

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -79,6 +79,7 @@ Rails.application.configure do
   # Use a different logger for distributed setups.
   # require 'syslog/logger'
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
+  config.logger = Logger.new(config.paths["log"].first, 5, 10.megabytes)
 
   if ENV["RAILS_LOG_TO_STDOUT"].present?
     logger           = ActiveSupport::Logger.new(STDOUT)


### PR DESCRIPTION
Otherwise log/production.log just keeps growing.