### PR TITLE
Add badge color to collection types

### DIFF
--- a/db/migrate/20180727212032_add_badge_color_to_collection_types.rb
+++ b/db/migrate/20180727212032_add_badge_color_to_collection_types.rb
@@ -1,0 +1,5 @@
+class AddBadgeColorToCollectionTypes < ActiveRecord::Migration[5.1]
+  def change
+     add_column :hyrax_collection_types, :badge_color, :string, default: '#663333'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180620001203) do
+ActiveRecord::Schema.define(version: 20180727212032) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -135,6 +135,7 @@ ActiveRecord::Schema.define(version: 20180620001203) do
     t.boolean "assigns_visibility", default: false, null: false
     t.boolean "share_applies_to_new_works", default: true, null: false
     t.boolean "brandable", default: true, null: false
+    t.string "badge_color", default: "#663333"
     t.index ["machine_id"], name: "index_hyrax_collection_types_on_machine_id", unique: true
   end
 


### PR DESCRIPTION
- Adds missing badge_color field to collection types; can't create new collections without this change. 
- See [rdr upgrade to 2.1.0](https://github.com/duke-libraries/rdr/blob/05a4b3717391b78b301aebb19dbcbca5737614e7/db/migrate/20180601173338_add_badge_color_to_collection_types.hyrax.rb)
