### PR TITLE
Add required title field at top of physical object form

### DIFF
--- a/app/assets/javascripts/hyrax/ms_physical_objects_form.js
+++ b/app/assets/javascripts/hyrax/ms_physical_objects_form.js
@@ -14,13 +14,14 @@ function hide_fields(field_array, clear = true) {
 
 function adjust_form_physical_object_type() {
 	if ($('#physical_object_physical_object_type').val() == 'BioSpec') {
-		show_fields(['.physical_object_idigbio_recordset_id', '.physical_object_idigbio_uuid', '.physical_object_is_type_specimen', '.physical_object_occurrence_id', '.physical_object_sex']);
-		hide_fields(['.physical_object_cho_type', '.physical_object_title', '.physical_object_contributor', '.physical_object_creator', '.physical_object_material']);
+		show_fields(['.physical_object_title','.physical_object_idigbio_recordset_id', '.physical_object_idigbio_uuid', '.physical_object_is_type_specimen', '.physical_object_occurrence_id', '.physical_object_sex']);
+		hide_fields(['.physical_object_cho_type', '.physical_object_contributor', '.physical_object_creator', '.physical_object_material']);
 	} else if ($('#physical_object_physical_object_type').val() == 'CHO') {
-		show_fields(['.physical_object_cho_type', '.physical_object_title', '.physical_object_contributor', '.physical_object_creator', '.physical_object_material']);
+		show_fields(['.physical_object_title','.physical_object_cho_type', '.physical_object_contributor', '.physical_object_creator', '.physical_object_material']);
 		hide_fields(['.physical_object_idigbio_recordset_id', '.physical_object_idigbio_uuid', '.physical_object_is_type_specimen', '.physical_object_occurrence_id', '.physical_object_sex']);
 	} else {
-		hide_fields(['.physical_object_cho_type', '.physical_object_title', '.physical_object_contributor', '.physical_object_creator', '.physical_object_material', '.physical_object_idigbio_recordset_id', '.physical_object_idigbio_uuid', '.physical_object_is_type_specimen', '.physical_object_occurrence_id', '.physical_object_sex']);
+		hide_fields(['.physical_object_cho_type', '.physical_object_contributor', '.physical_object_creator', '.physical_object_material', '.physical_object_idigbio_recordset_id', '.physical_object_idigbio_uuid', '.physical_object_is_type_specimen', '.physical_object_occurrence_id', '.physical_object_sex']);
+		show_fields(['.physical_object_title']);
 	}
 }
 

--- a/app/forms/hyrax/physical_object_form.rb
+++ b/app/forms/hyrax/physical_object_form.rb
@@ -28,6 +28,7 @@ module Hyrax
        :periodic_time,
        # :publisher,
        # :related_url,
+       # :title,
        :vouchered,
 
        # Biological Specimens only
@@ -39,7 +40,7 @@ module Hyrax
 
        # CHOs only
        :cho_type,
-       # :title,
+
        # :contributor,
        # :creator,
        :material
@@ -47,7 +48,7 @@ module Hyrax
 
     self.terms -= [:based_near, :keyword, :license, :rights_statement, :subject, :language, :source, :resource_type]
 
-    self.required_fields = [:vouchered, :physical_object_type]
+    self.required_fields = [:title, :vouchered, :physical_object_type]
 
     self.single_valued_fields = [
       :bibliographic_citation,


### PR DESCRIPTION
Since title is required as part of the core metadata, the field needs to be filled out in order to save a physical object. This commit marks it as required on the form, and moves it to the top of the page.