### PR TITLE
Fix for Saving Media Works

### DIFF
--- a/app/assets/javascripts/hyrax/ms_media_form.js
+++ b/app/assets/javascripts/hyrax/ms_media_form.js
@@ -6,13 +6,14 @@ function show_fields(field_array) {
 
 function hide_fields(field_array, clear = true) {
 	$(field_array.join(',')).addClass('hide');
-	if (clear) { 
+	if (clear) {
 		console.log(field_array.join(','));
-		$(field_array.join(',')).children('input, select').val(''); 
+		$(field_array.join(',')).children('input, select').val('');
 	}
 }
 
 function adjust_form_media_type() {
+	show_fields(['.media_title']);
 	if ($('#media_media_type').val() == 'CTImageStack') {
 		show_fields(['.media_x_spacing', '.media_y_spacing', '.media_z_spacing', '.media_unit']);
 		hide_fields(['.media_scale_bar_target_type', '.media_scale_bar_distance', '.media_map_type']);

--- a/app/assets/javascripts/hyrax/ms_physical_objects_form.js
+++ b/app/assets/javascripts/hyrax/ms_physical_objects_form.js
@@ -13,14 +13,15 @@ function hide_fields(field_array, clear = true) {
 }
 
 function adjust_form_physical_object_type() {
+	show_fields(['.physical_object_title']);
 	if ($('#physical_object_physical_object_type').val() == 'BioSpec') {
 		show_fields(['.physical_object_idigbio_recordset_id', '.physical_object_idigbio_uuid', '.physical_object_is_type_specimen', '.physical_object_occurrence_id', '.physical_object_sex']);
-		hide_fields(['.physical_object_cho_type', '.physical_object_title', '.physical_object_contributor', '.physical_object_creator', '.physical_object_material']);
+		hide_fields(['.physical_object_cho_type', '.physical_object_contributor', '.physical_object_creator', '.physical_object_material']);
 	} else if ($('#physical_object_physical_object_type').val() == 'CHO') {
-		show_fields(['.physical_object_cho_type', '.physical_object_title', '.physical_object_contributor', '.physical_object_creator', '.physical_object_material']);
+		show_fields(['.physical_object_cho_type', '.physical_object_contributor', '.physical_object_creator', '.physical_object_material']);
 		hide_fields(['.physical_object_idigbio_recordset_id', '.physical_object_idigbio_uuid', '.physical_object_is_type_specimen', '.physical_object_occurrence_id', '.physical_object_sex']);
 	} else {
-		hide_fields(['.physical_object_cho_type', '.physical_object_title', '.physical_object_contributor', '.physical_object_creator', '.physical_object_material', '.physical_object_idigbio_recordset_id', '.physical_object_idigbio_uuid', '.physical_object_is_type_specimen', '.physical_object_occurrence_id', '.physical_object_sex']);
+		hide_fields(['.physical_object_cho_type', '.physical_object_contributor', '.physical_object_creator', '.physical_object_material', '.physical_object_idigbio_recordset_id', '.physical_object_idigbio_uuid', '.physical_object_is_type_specimen', '.physical_object_occurrence_id', '.physical_object_sex']);
 	}
 }
 

--- a/app/forms/hyrax/media_form.rb
+++ b/app/forms/hyrax/media_form.rb
@@ -5,14 +5,18 @@ module Hyrax
   class MediaForm < Hyrax::Forms::WorkForm
     self.model_class = ::Media
 
+    include SingleValuedForm
+
+    class_attribute :single_value_fields
+
     # Customizing field terms
 
-    self.terms = [:title, :modality, :media_type, :x_spacing, :y_spacing, :z_spacing, 
-                    :scale_bar_target_type, :scale_bar_distance, :unit, :map_type, 
-                    :part, :side, :orientation, 
-                    :description, :keyword, :identifier, :related_url, :creator, :date_created, 
-                    :funding, :license, :rights_statement, :agreement_uri, 
-                    :rights_holder, :cite_as, :publisher,     
+    self.terms = [:title, :modality, :media_type, :x_spacing, :y_spacing, :z_spacing,
+                    :scale_bar_target_type, :scale_bar_distance, :unit, :map_type,
+                    :part, :side, :orientation,
+                    :description, :keyword, :identifier, :related_url, :creator, :date_created,
+                    :funding, :license, :rights_statement, :agreement_uri,
+                    :rights_holder, :cite_as, :publisher,
                     :representative_id, :thumbnail_id, :rendering_ids, :files,
                     :visibility_during_embargo, :embargo_release_date, :visibility_after_embargo,
                     :visibility_during_lease, :lease_expiration_date, :visibility_after_lease,
@@ -20,6 +24,8 @@ module Hyrax
                     :member_of_collection_ids, :admin_set_id]
 
     self.required_fields = [:title, :modality, :media_type]
+
+    self.single_valued_fields = [:title, :media_type, :cite_as, :legacy_media_file_id, :legacy_media_group_id, :uuid, :ark, :doi, :available, :x_spacing, :y_spacing, :z_spacing, :scale_bar_target_type, :scale_bar_distance, :unit]
 
   end
 end

--- a/app/forms/hyrax/physical_object_form.rb
+++ b/app/forms/hyrax/physical_object_form.rb
@@ -28,6 +28,7 @@ module Hyrax
        :periodic_time,
        # :publisher,
        # :related_url,
+       # :title,
        :vouchered,
 
        # Biological Specimens only
@@ -39,7 +40,6 @@ module Hyrax
 
        # CHOs only
        :cho_type,
-       # :title,
        # :contributor,
        # :creator,
        :material
@@ -47,7 +47,7 @@ module Hyrax
 
     self.terms -= [:based_near, :keyword, :license, :rights_statement, :subject, :language, :source, :resource_type]
 
-    self.required_fields = [:vouchered, :physical_object_type]
+    self.required_fields = [:title, :vouchered, :physical_object_type]
 
     self.single_valued_fields = [
       :bibliographic_citation,

--- a/app/models/concerns/morphosource/media_metadata.rb
+++ b/app/models/concerns/morphosource/media_metadata.rb
@@ -1,18 +1,18 @@
 module Morphosource
-  # Module to define core (non-modality specific) metadata properties for 
+  # Module to define core (non-modality specific) metadata properties for
   # media works
   module MediaMetadata
 	extend ActiveSupport::Concern
 
-	included do 
+	included do
 	  # -- Core metadata --
 
-	  # Required select values 
+	  # Required select values
 	  property :modality, predicate: ::RDF::URI.new("http://rs.tdwg.org/ac/terms/captureDevice") do |index|
 	  	index.as :stored_searchable, :facetable
 	  end
 
-	  property :media_type, predicate: ::RDF::URI.new("http://rs.tdwg.org/ac/terms/subtypeLiteral"), multiple: false do |index|
+	  property :media_type, predicate: ::RDF::URI.new("http://rs.tdwg.org/ac/terms/subtypeLiteral") do |index|
 		index.as :stored_searchable, :facetable
 	  end
 
@@ -34,7 +34,7 @@ module Morphosource
 		index.as :stored_searchable
 	  end
 
-	  property :cite_as, predicate: ::RDF::URI.new("http://ns.adobe.com/photoshop/1.0/Credit"), multiple: false do |index|
+	  property :cite_as, predicate: ::RDF::URI.new("http://ns.adobe.com/photoshop/1.0/Credit") do |index|
 		index.as :stored_searchable
 	  end
 
@@ -47,27 +47,27 @@ module Morphosource
 	  end
 
 	  # Fields not present on edit/show form
-	  property :legacy_media_file_id, predicate: ::RDF::URI.new("http://rs.tdwg.org/ac/terms/providerManagedID"), multiple: false do |index|
+	  property :legacy_media_file_id, predicate: ::RDF::URI.new("http://rs.tdwg.org/ac/terms/providerManagedID") do |index|
 		index.as :stored_searchable
 	  end
 
-	  property :legacy_media_group_id, predicate: ::RDF::URI.new("http://rs.tdwg.org/ac/terms/IDofContainingCollection"), multiple: false do |index|
+	  property :legacy_media_group_id, predicate: ::RDF::URI.new("http://rs.tdwg.org/ac/terms/IDofContainingCollection") do |index|
 		index.as :stored_searchable
 	  end
 
-	  property :uuid, predicate: ::RDF::URI.new("https://www.morphosource.org/terms/mediaUUID"), multiple: false do |index|
+	  property :uuid, predicate: ::RDF::URI.new("https://www.morphosource.org/terms/mediaUUID") do |index|
 		index.as :stored_searchable
 	  end
 
-	  property :ark, predicate: ::RDF::URI.new("https://www.morphosource.org/terms/mediaARK"), multiple: false do |index|
+	  property :ark, predicate: ::RDF::URI.new("https://www.morphosource.org/terms/mediaARK") do |index|
 		index.as :stored_searchable
 	  end
 
-	  property :doi, predicate: ::RDF::URI.new("https://www.morphosource.org/terms/mediaDOI"), multiple: false do |index|
+	  property :doi, predicate: ::RDF::URI.new("https://www.morphosource.org/terms/mediaDOI") do |index|
 		index.as :stored_searchable
 	  end
 
-	  property :available, predicate: ::RDF::Vocab::DC.available, multiple: false do |index|
+	  property :available, predicate: ::RDF::Vocab::DC.available do |index|
 		index.as :stored_searchable
 	  end
 
@@ -79,29 +79,29 @@ module Morphosource
 	  end
 
 	  # CTImageStack fields
-	  property :x_spacing, predicate: ::RDF::URI.new("https://www.morphosource.org/terms/dicomPixelSpacingWidth"), multiple: false do |index|
+	  property :x_spacing, predicate: ::RDF::URI.new("https://www.morphosource.org/terms/dicomPixelSpacingWidth") do |index|
 		index.as :stored_searchable
 	  end
 
-	  property :y_spacing, predicate: ::RDF::URI.new("https://www.morphosource.org/terms/dicomPixelSpacingHeight"), multiple: false do |index|
+	  property :y_spacing, predicate: ::RDF::URI.new("https://www.morphosource.org/terms/dicomPixelSpacingHeight") do |index|
 		index.as :stored_searchable
 	  end
 
-	  property :z_spacing, predicate: ::RDF::URI.new("https://www.morphosource.org/terms/dicomSpacingBetweenSlices"), multiple: false do |index|
+	  property :z_spacing, predicate: ::RDF::URI.new("https://www.morphosource.org/terms/dicomSpacingBetweenSlices") do |index|
 		index.as :stored_searchable
 	  end
 
 	  # PhotogrammetryImageStack fields
-	  property :scale_bar_target_type, predicate: ::RDF::URI.new("https://www.morphosource.org/terms/scaleBarTargetType"), multiple: false do |index|
+	  property :scale_bar_target_type, predicate: ::RDF::URI.new("https://www.morphosource.org/terms/scaleBarTargetType") do |index|
 		index.as :stored_searchable
 	  end
 
-	  property :scale_bar_distance, predicate: ::RDF::URI.new("https://www.morphosource.org/terms/scaleBarDistance"), multiple: false do |index|
+	  property :scale_bar_distance, predicate: ::RDF::URI.new("https://www.morphosource.org/terms/scaleBarDistance") do |index|
 		index.as :stored_searchable
 	  end
 
 	  # Mesh and CTImageStack field
-	  property :unit, predicate: ::RDF::URI.new("https://www.morphosource.org/terms/ACExt/units"), multiple: false do |index|
+	  property :unit, predicate: ::RDF::URI.new("https://www.morphosource.org/terms/ACExt/units") do |index|
 		index.as :stored_searchable, :facetable
 	  end
 


### PR DESCRIPTION
Adding single-value fields to physical object works prevented media works from recognizing the title field on save. Adding single-value fields to media works fixes this problem. 