### PR TITLE
Fix partial that was hiding title fields

### DIFF
--- a/app/assets/javascripts/hyrax/ms_media_form.js
+++ b/app/assets/javascripts/hyrax/ms_media_form.js
@@ -28,7 +28,6 @@ function adjust_form_media_type() {
 }
 
 $(document).ready(function () {
-	show_fields(['.media_title']);
 	hide_fields(['.media_scale_bar','.media_number_of_images_in_set']);
 	adjust_form_media_type();
 });

--- a/app/assets/javascripts/hyrax/ms_physical_objects_form.js
+++ b/app/assets/javascripts/hyrax/ms_physical_objects_form.js
@@ -25,7 +25,6 @@ function adjust_form_physical_object_type() {
 }
 
 $(document).ready(function () {
-	show_fields(['.physical_object_title']);
 	adjust_form_physical_object_type();
 });
 

--- a/app/views/records/edit_fields/_title.html.erb
+++ b/app/views/records/edit_fields/_title.html.erb
@@ -1,3 +1,3 @@
 <% # app/views/records/edit_fields/_title.html.erb %>
 <%= f.input :title, as: :string,
-    wrapper_html: { class: 'hide' } %>
+    wrapper_html: { class: 'show' } %>


### PR DESCRIPTION
- Discovered that the title partial had a 'hide' class on it, which had been messing with its appearance on the work form. Fixed the partial and removed code from javascripts that is no longer needed. 