### PR TITLE
Scale bar Fix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,7 +46,6 @@ group :development do
   gem 'listen', '>= 3.0.5', '< 3.2'
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
-  gem 'xray-rails'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -830,8 +830,6 @@ GEM
     xml-simple (1.1.5)
     xpath (3.1.0)
       nokogiri (~> 1.8)
-    xray-rails (0.3.1)
-      rails (>= 3.1.0)
 
 PLATFORMS
   ruby
@@ -877,7 +875,6 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
   webmock
-  xray-rails
 
 BUNDLED WITH
    1.16.5

--- a/app/assets/javascripts/hyrax/ms_media_form.js
+++ b/app/assets/javascripts/hyrax/ms_media_form.js
@@ -7,7 +7,6 @@ function show_fields(field_array) {
 function hide_fields(field_array, clear = true) {
 	$(field_array.join(',')).addClass('hide');
 	if (clear) {
-		console.log(field_array.join(','));
 		$(field_array.join(',')).children('input, select').val('');
 	}
 }
@@ -15,22 +14,22 @@ function hide_fields(field_array, clear = true) {
 function adjust_form_media_type() {
 	if ($('#media_media_type').val() == 'CTImageStack') {
 		show_fields(['.media_x_spacing', '.media_y_spacing', '.media_z_spacing', '.media_unit']);
-		hide_fields(['.media_map_type', '#media_scale_bar_wrapper']);
+		hide_fields(['.media_map_type', '#media_scale_bar_wrapper', '#media_scale_bar_target_type', '#media_scale_bar_distance', '#media_scale_bar_units']);
 	} else if ($('#media_media_type').val() == 'PhotogrammetryImageStack') {
-		show_fields(['#media_scale_bar_wrapper']);
+		show_fields(['#media_scale_bar_wrapper', '#media_scale_bar_target_type', '#media_scale_bar_distance', '#media_scale_bar_units']);
 		hide_fields(['.media_x_spacing', '.media_y_spacing', '.media_z_spacing', '.media_unit', '.media_map_type']);
 	} else if ($('#media_media_type').val() == 'Mesh') {
 		show_fields(['.media_unit', '.media_map_type']);
-		hide_fields(['.media_x_spacing', '.media_y_spacing', '.media_z_spacing', '#media_scale_bar_wrapper']);
+		hide_fields(['.media_x_spacing', '.media_y_spacing', '.media_z_spacing', '#media_scale_bar_wrapper', '#media_scale_bar_target_type', '#media_scale_bar_distance', '#media_scale_bar_units']);
 	} else {
-		hide_fields(['.media_x_spacing', '.media_y_spacing', '.media_z_spacing', '.media_unit', '.media_map_type', '#media_scale_bar_wrapper']);
+		hide_fields(['.media_x_spacing', '.media_y_spacing', '.media_z_spacing', '.media_unit', '.media_map_type', '#media_scale_bar_wrapper', '#media_scale_bar_target_type', '#media_scale_bar_distance', '#media_scale_bar_units']);
 	}
 }
 
-$(document).ready(function () {
+$(document).on('turbolinks:load', function() {
 	hide_fields(['.media_number_of_images_in_set','.media_scale_bar']);
 	adjust_form_media_type();
-});
+})
 
 $(document).on('change', '#media_media_type', function() {
 	adjust_form_media_type();

--- a/app/views/records/edit_fields/_scale_bar.html.erb
+++ b/app/views/records/edit_fields/_scale_bar.html.erb
@@ -1,6 +1,5 @@
 <% # app/views/records/edit_fields/_scale_bar.html.erb %>
-<%= f.input :scale_bar, as: :multi_value,
-    wrapper_html: { class: 'hide' } %>
+<%= f.input :scale_bar, as: :multi_value %>
 
 <div id="media_scale_bar_wrapper" class="form-group multi_value optional managed" style="margin-right:7em;">
 
@@ -11,7 +10,7 @@
       <div style="width:30%;"><label for="media_scale_bar_target_type">Target Type</label></div>
       <div style="width:30%;"><label>Distance</label></div>
       <div style="width:30%;"><label>Units</label></div>
-  </div>
+    </div>
     <li class="field-wrapper input-group input-append" style="display:flex; flex-direction:row; justify-content:space-evenly;">
       <input class="string multi_value optional form-control media_scale_bar_target_type form-control multi-text-field" name="media[scale_bar_target_type][]" value="" id="media_scale_bar_target_type" type="text" style="margin:5px; width:30%; border-radius:5px;">
       <input class="string multi_value optional form-control media_scale_bar_distance form-control multi-text-field" name="media[scale_bar_distance][]" value="" id="media_scale_bar_distance" type="text" style="margin:5px; width:30%; border-radius:5px;">
@@ -35,8 +34,21 @@ var scaleBarWrapper = document.getElementById("media_scale_bar_wrapper");
 var scaleBarWrapperUl = scaleBarWrapper.querySelector('ul');
 var scaleBarWrapperLi = scaleBarWrapper.querySelector('li');
 
-// Using JQuery because window.addEventListener('onload') was not loading except for page refresh:
-$(document).ready(function(){
+// Puts concatenated values into scale bar on submit.
+function buildScaleBar(scaleBar) {
+  var li = document.createElement('li');
+
+  var input = document.createElement('input');
+  input.className = 'string multi_value optional media_scale_bar form-control multi-text-field';
+  input.setAttribute("id", "media_scale_bar");
+  input.setAttribute("name", "media[scale_bar][]");
+  input.value = scaleBar
+
+  li.appendChild(input);
+  scaleBarGroupUl.appendChild(li);
+}
+
+$(document).on('turbolinks:load', function(){
 
   // When editing a record, this populates the three-part scale bar fields with previously saved metadata.
   for (i = 0; i < concatScaleBarCount; i++) {
@@ -84,6 +96,18 @@ $(document).ready(function(){
     unitsInput.value = units;
     li.appendChild(unitsInput);
 
+    var span = document.createElement('span');
+    span.className = "input-group-btn field-controls";
+    span.innerHTML = `<button type="button" class="btn btn-link remove">
+                        <span class="glyphicon glyphicon-remove"></span>
+                        <span class="controls-remove-text">Remove</span>
+                        <span class="sr-only"> previous
+                          <span class="controls-field-name-text"> Scale Bar</span>
+                        </span>
+                      </button>`
+
+    li.appendChild(span);
+
     scaleBarWrapperUl.appendChild(li);
 
     }
@@ -95,32 +119,29 @@ $(document).ready(function(){
   // On submit, type/distance/units fields are concatenated and inserted into hidden default scale bar field.
   form.addEventListener("submit", function() {
 
-  var scaleBarCount = document.getElementsByClassName("media_scale_bar_target_type").length;
+    // If media type = photogrammetry, submit scale bar fields. Otherwise, submit an empty scale bar.
+    if($('#media_media_type').val() == 'PhotogrammetryImageStack') {
 
-    for (i = 0; i < scaleBarCount; i++) {
+      var scaleBarCount = document.getElementsByClassName("media_scale_bar_target_type").length;
 
-      var targetType = document.getElementsByClassName("media_scale_bar_target_type")[i].value || '';
-      var scaleBarDistance = document.getElementsByClassName("media_scale_bar_distance")[i].value || '';
-      var scaleBarUnits = document.getElementsByClassName("media_scale_bar_units")[i].value || '';
+      for (i = 0; i < scaleBarCount; i++) {
 
-      // As long as at least one input is filled out, proceed with creating a scale bar string. Otherwise, create an empty string, which will not result in a new scale bar triple.
-      if ((targetType != '') || (scaleBarDistance != '') || (scaleBarUnits != '')) {
-        var scaleBar = "Type: " + targetType + ", Distance: " + scaleBarDistance + ", Units: " +  scaleBarUnits;
+        var targetType = document.getElementsByClassName("media_scale_bar_target_type")[i].value || '';
+        var scaleBarDistance = document.getElementsByClassName("media_scale_bar_distance")[i].value || '';
+        var scaleBarUnits = document.getElementsByClassName("media_scale_bar_units")[i].value || '';
+
+        // As long as at least one input is filled out, proceed with creating a scale bar string. Otherwise, create an empty string, which will not result in a new scale bar triple.
+        if ((targetType != '') || (scaleBarDistance != '') || (scaleBarUnits != '')) {
+          var scaleBar = "Type: " + targetType + ", Distance: " + scaleBarDistance + ", Units: " +  scaleBarUnits;
+        }
+        else {
+          var scaleBar = ''
+        }
+        buildScaleBar(scaleBar);
       }
-      else {
-        var scaleBar = ''
-      }
-
-      var li = document.createElement('li');
-
-      var input = document.createElement('input');
-      input.className = 'string multi_value optional media_scale_bar form-control multi-text-field';
-      input.setAttribute("id", "media_scale_bar");
-      input.setAttribute("name", "media[scale_bar][]");
-      input.value = scaleBar
-
-      li.appendChild(input);
-      scaleBarGroupUl.appendChild(li);
+    }
+    else {
+      buildScaleBar('');
     }
   });
 });


### PR DESCRIPTION
- Xray-rails was messing with the show/hide functions on the work form, so I took it out for now. 
- Put the logic for clearing the scale bar inputs in the scale bar field javascript, so they are available to a user while editing even if they switch media types, and only are cleared if the media type is not photogrammetry on submit.