### PR TITLE
Enable public file server for UV in production environment

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -21,7 +21,7 @@ Rails.application.configure do
 
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.
-  config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
+  config.public_file_server.enabled = true
 
   # Compress JavaScripts and CSS.
   #config.assets.js_compressor = :uglifier


### PR DESCRIPTION
Enable public file server is a requirement for using UV in production environments (i.e., https://github.com/samvera/hyrax/issues/2326). This commit enables the public file server for production.