### PR TITLE
Create institution select page as first step in Submission process; M…

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -24,3 +24,4 @@
 //= require hyrax
 //= require morphosource/add_parent
 //= require morphosource/editor
+//= require select2

--- a/app/helpers/morphosource_helper.rb
+++ b/app/helpers/morphosource_helper.rb
@@ -8,6 +8,13 @@ module MorphosourceHelper
     end
   end
 
+  def institution_selector
+    sortable_title_field = Solrizer.solr_name('title', :stored_sortable)
+    qry = "#{Solrizer.solr_name('has_model', :symbol)}:Institution"
+    hits = ActiveFedora::SolrService.query(qry, rows: 999999, sort: "#{sortable_title_field} ASC")
+    hits.map { |hit| [ hit[sortable_title_field], hit.id ] }
+  end
+
   def find_works_autocomplete_url(curation_concern, relation)
     valid_concerns = curation_concern.send("valid_#{relation}_concerns").map(&:to_s)
     type_params = valid_concerns.sort.map { |type| "type[]=#{type}" }

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -22,7 +22,7 @@ class Ability
     # end
 
     if registered_user?
-      can [ :create ], Submission
+      can [ :create, :show ], Submission
     end
 
   end

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -1,6 +1,29 @@
-class Submission
-  include ActiveModel::Model
+class Submission < ActiveRecord::Base
 
-  attr_accessor :find_parent_work
+  attr_writer :current_step
+
+  def steps
+    %w(institution)
+  end
+
+  def current_step
+    @current_step || steps.first
+  end
+
+  def first_step?
+    current_step == steps.first
+  end
+
+  def last_step?
+    current_step == steps.last
+  end
+
+  def next_step
+    self.current_step = steps[steps.index(current_step) + 1]
+  end
+
+  def previous_step
+    self.current_step = steps[steps.index(current_step) - 1]
+  end
 
 end

--- a/app/views/submissions/_institution_step.html.erb
+++ b/app/views/submissions/_institution_step.html.erb
@@ -1,0 +1,14 @@
+<%# TODO: This may not be the best place for this script. %>
+<script>
+    $(document).ready(function () {
+        $("#submission_institution_id").select2();
+    });
+</script>
+
+<div class="form-group">
+  <div class="form-inline">
+    <%# TODO: Width set to an arbitrary pixel value for now.  This is probably not appropriate for accessibility. %>
+    <%= f.input :institution_id, collection: institution_selector, prompt: 'Select institution',
+                input_html: {style: 'width: 400px'} %>
+  </div>
+</div>

--- a/app/views/submissions/new.html.erb
+++ b/app/views/submissions/new.html.erb
@@ -1,40 +1,13 @@
-<% provide :page_title, curation_concern_page_title(@curation_concern) %>
+<% provide :page_title, t('morphosource.submission.page_title') %>
 <% provide :page_header do %>
-  <h1><%= t("hyrax.works.create.header", type: @curation_concern.human_readable_type) %></h1>
+  <h1><%= t('morphosource.submission.page_header') %></h1>
 <% end %>
 
-<div>Your new <%= @curation_concern.human_readable_type %> must belong to one the following types of objects:
-  <%= valid_work_types_list(@curation_concern, :parent) %>.</div>
+<%= simple_form_for @submission do |f| %>
 
-<h3>Either select an existing work (<%= valid_work_types_list(@curation_concern, :parent) %>)</h3>
-<%= simple_form_for @submission,
-    html: {
-        data: { behavior: 'work-form', 'param-key' => 'submission' },
-    } do |f| %>
+  <%= render "#{@submission.current_step}_step", f: f %>
 
-  <div class="form-group" data-behavior="parent-relationships" data-param-key="submission" data-members="[]">
-    <div class="form-inline">
-      <%= f.label :find_parent_work %>
-      <%= f.input_field :find_parent_work,
-                        prompt: :translate,
-                        autocomplete: 'off',
-                        data: {
-                            autocomplete: 'work',
-                            'autocomplete-url' => find_works_autocomplete_url(@curation_concern, :parent),
-                            'exclude-work': "NewRecord" # exclude this item from the result set.
-                        } %>
-      <%= f.submit 'Next' %>
-    </div>
-    <div class="message has-warning hidden"></div>
-  </div>
+  <%= f.submit 'Continue' %>
+  <%= f.submit 'Back', name: 'previous_button' unless @submission.first_step? %>
 
-<% end %>
-
-<h3>Or create a new work if the appropriate one does not already exist</h3>
-<% @curation_concern.valid_parent_concerns.map(&:to_s).sort.each do |concern| %>
-  <% @create_path = "new_hyrax_#{concern.underscore}" %>
-  <%= link_to("Create #{concern.constantize.human_readable_type}",
-              [ main_app, @create_path ],
-              class: "btn btn-info",
-              role: "button") %>
 <% end %>

--- a/app/views/submissions/show.html.erb
+++ b/app/views/submissions/show.html.erb
@@ -1,0 +1,13 @@
+<% provide :page_title, t('morphosource.submission.page_title') %>
+<% provide :page_header do %>
+  <h1><%= t('morphosource.submission.page_header') %></h1>
+<% end %>
+
+<h2>Placeholder End Page</h2>
+
+<h4>Submission Info</h4>
+
+<dl>
+  <dt>Institution</dt>
+  <dd><%= "#{@institution.title.first} (#{@submission.institution_id})" %></dd>
+</dl>

--- a/config/locales/morphosource.en.yml
+++ b/config/locales/morphosource.en.yml
@@ -1,5 +1,8 @@
 en:
   morphosource:
+    submission:
+      page_title: 'Submit Media // MorphoSource'
+      page_header: 'Submit Media File(s)'
     validation:
       missing:
         title: 'Your work must have a title.'

--- a/db/migrate/20181113194516_create_submission.rb
+++ b/db/migrate/20181113194516_create_submission.rb
@@ -1,0 +1,7 @@
+class CreateSubmission < ActiveRecord::Migration[5.1]
+  def change
+    create_table :submissions do |t|
+      t.string :institution_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180727212032) do
+ActiveRecord::Schema.define(version: 20181113194516) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -472,6 +472,10 @@ ActiveRecord::Schema.define(version: 20180727212032) do
     t.boolean "active"
     t.boolean "allows_access_grant"
     t.index ["permission_template_id", "name"], name: "index_sipity_workflows_on_permission_template_and_name", unique: true
+  end
+
+  create_table "submissions", force: :cascade do |t|
+    t.string "institution_id"
   end
 
   create_table "tinymce_assets", force: :cascade do |t|

--- a/spec/helpers/morphosource_helper_spec.rb
+++ b/spec/helpers/morphosource_helper_spec.rb
@@ -58,6 +58,17 @@ RSpec.describe MorphosourceHelper, type: :helper do
     end
   end
 
+  describe '#institution_selector' do
+    let!(:institutions) do
+      [ Institution.create(title: [ 'Foo' ]),
+        Institution.create(title: [ 'Bar' ]) ]
+    end
+    it 'returns the appropriate array' do
+      expect(helper.institution_selector).to eq([ [ institutions[1].title.first, institutions[1].id ],
+                                                  [ institutions[0].title.first, institutions[0].id ] ])
+    end
+  end
+
   describe '#ms_work_form_tabs' do
     let(:work) { double }
     let(:with_files_tab) { [ 'metadata', 'files', 'relationships' ] }

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -7,17 +7,26 @@ RSpec.describe Ability, type: :model do
 
   subject { Ability.new(user) }
 
-  describe 'create submissions' do
-
-    describe 'logged in' do
-      before { allow(user).to receive(:groups) { [ 'registered' ] } }
-      it { is_expected.to be_able_to(:create, Submission) }
+  describe 'submissions' do
+    describe 'create' do
+      describe 'logged in' do
+        before { allow(user).to receive(:groups) { [ 'registered' ] } }
+        it { is_expected.to be_able_to(:create, Submission) }
+      end
+      describe 'not logged in' do
+        it { is_expected.to_not be_able_to(:create, Submission) }
+      end
     end
-
-    describe 'not logged in' do
-      it { is_expected.to_not be_able_to(:create, Submission) }
+    describe 'show' do
+      let(:submission) { Submission.new }
+      describe 'logged in' do
+        before { allow(user).to receive(:groups) { [ 'registered' ] } }
+        it { is_expected.to be_able_to(:show, submission) }
+      end
+      describe 'not logged in' do
+        it { is_expected.to_not be_able_to(:show, submission) }
+      end
     end
-
   end
 
 end

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -1,5 +1,41 @@
 require 'rails_helper'
 
 RSpec.describe Submission, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+
+  describe 'steps' do
+    specify { expect(subject.steps).to eq(%w(institution)) }
+    specify { expect(subject.current_step).to eq('institution') }
+
+    describe '#first_step?' do
+      describe 'current step is first step' do
+        before { subject.current_step = 'institution' }
+        specify { expect(subject.first_step?).to be true }
+      end
+      describe 'current step is not first step' do
+        before { subject.current_step = 'object' }
+        specify { expect(subject.first_step?).to be false }
+      end
+    end
+
+    describe '#last_step?' do
+      describe 'current step is last step' do
+        before { subject.current_step = 'institution' }
+        specify { expect(subject.last_step?).to be true }
+      end
+      describe 'current step is not last step' do
+        before { subject.current_step = 'object' }
+        specify { expect(subject.last_step?).to be false }
+      end
+    end
+
+    describe '#next_step' do
+      pending 'inclusion of more than one step'
+    end
+
+    describe '#next_step' do
+      pending 'inclusion of more than one step'
+    end
+
+  end
+
 end


### PR DESCRIPTION
…R-317.

The institution select widget presents a list of all institutions and uses 'select2' to
add autocomplete/typeahead functionality to facilitate selection.
This PR also establishes the beginning of a wizard framework for the Submission process
using the techniques described in http://railscasts.com/episodes/217-multistep-forms.