### PR TITLE
MR-172: Google Analytics API integration and configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@
 # Ignore application configuration
 /config/application.yml
 
+# Google Analytics config
+/config/analytics.yml
+
 # ---------------------------------------------------
 # Below are copied from RDR. Might need them later
 # ---------------------------------------------------

--- a/app/assets/javascripts/hyrax/ga_events.js
+++ b/app/assets/javascripts/hyrax/ga_events.js
@@ -1,0 +1,11 @@
+// Overrides hyrax/app/assets/javascripts/hyrax/ga_events.js
+// in order to use gtag.js library instead of legacy ga.js
+
+// Documentation: https://developers.google.com/analytics/devguides/collection/gtagjs/events
+
+$(document).on('click', '#file_download', function(e) {
+  gtag('event', 'Downloaded', {
+    'event_category': 'Files',
+    'event_label': $(this).data('label')
+  });
+});

--- a/app/views/_ga.html.erb
+++ b/app/views/_ga.html.erb
@@ -1,0 +1,17 @@
+<%# Overrides hyrax/app/views/_ga.html.erb, which uses the long-deprecated ga.js library. %>
+<%# Its successor analytics.js is also deprecated. Instead, use modern gtag.js tracking. %>
+
+<%
+if Hyrax.config.google_analytics_id?
+tracking_id = Hyrax.config.google_analytics_id
+%>
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=<%= tracking_id %>"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', '<%= tracking_id %>', { 'anonymize_ip': true, 'transport_type': 'beacon' });
+</script>
+
+<% end %>

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -1,9 +1,0 @@
-#
-# To integrate your app with Google Analytics, uncomment the lines below and add your API key information.
-#
-# analytics:
-#   app_name: GOOGLE_OAUTH_APP_NAME
-#   app_version: GOOGLE_OAUTH_APP_VERSION
-#   privkey_path: GOOGLE_OAUTH_PRIVATE_KEY_PATH
-#   privkey_secret: GOOGLE_OAUTH_PRIVATE_KEY_SECRET
-#   client_email: GOOGLE_OAUTH_CLIENT_EMAIL

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -61,9 +61,11 @@ Hyrax.config do |config|
   # Defaults to false
   # Requires a Google Analytics id and OAuth2 keyfile.  See README for more info
   # config.analytics = false
+  config.analytics = ENV['TRACK_GOOGLE_ANALYTICS'] == 'true' ? true : false
 
   # Google Analytics tracking ID to gather usage statistics
   # config.google_analytics_id = 'UA-99999999-1'
+  config.google_analytics_id = ENV['GOOGLE_ANALYTICS_TRACKING_ID']
 
   # Date you wish to start collecting Google Analytic statistics for
   # Leaving it blank will set the start date to when ever the file was uploaded by

--- a/config/initializers/legato.rb
+++ b/config/initializers/legato.rb
@@ -1,0 +1,10 @@
+Rails.application.config.after_initialize do
+  # If Google Analytics are enabled, pre-load the models which rely on
+  # Legato::Model.extended(base) dynamic profile method generation. Non-production
+  # environments wouldn't necessarily have this eager loaded by default.
+  if Hyrax.config.analytics
+    require 'legato'
+    require 'hyrax/pageview'
+    require 'hyrax/download'
+  end
+end


### PR DESCRIPTION
- Captures usage and download statistics that can be viewed through the MorphoSource Google Analytics account.
- Displays usage in the UI
- Creates separate tracking IDs for development, preproduction, and production. 
- Instructions to set up for your development environment to follow.