### PR TITLE
MR-346: Refactor getting file names for previous uploads

### DIFF
--- a/app/views/hyrax/base/_form_relationships.html.erb
+++ b/app/views/hyrax/base/_form_relationships.html.erb
@@ -15,8 +15,4 @@
 <% if f.object.persisted? %>
   <h2><%= t("hyrax.works.form.in_this_work") %></h2>
   <%= render 'form_child_work_relationships', f: f %>
-  <%# Below renders a hidden list of previously uploaded files used by upload_formats.js to evalute the file formats requirement on Media works %>
-  <% if f.object.model_name.name == 'Media' %>
-    <%= render 'form_uploads_list', f: f %>
-  <% end %>
 <% end %>

--- a/app/views/hyrax/base/_form_uploads_list.html.erb
+++ b/app/views/hyrax/base/_form_uploads_list.html.erb
@@ -1,9 +1,0 @@
-<!-- Adds hidden list of previously uploaded file names used by upload_formats.js to evaluate the file formats requirement on Media works -->
-<div id="uploaded_files_list" class="hide">
-  <% file_list = curation_concern.file_sets.map{|f| f.label} %>
-  <ul>
-  <% file_list.each do |f| %>
-    <li><%= f %></li>
-  <% end %>
-  </ul>
-</div>

--- a/lib/assets/javascripts/morphosource/media/upload_formats.js.erb
+++ b/lib/assets/javascripts/morphosource/media/upload_formats.js.erb
@@ -14,7 +14,7 @@ function newFiles(){
 
 // Returns an array of file names of previously uploaded files.
 function oldFiles(){
-  return fileNames($('#uploaded_files_list > ul > li'));
+  return fileNames($('#media_representative_id > option'));
 }
 
 function regularExpressionize(list) {

--- a/lib/assets/javascripts/morphosource/media/upload_formats.js.erb
+++ b/lib/assets/javascripts/morphosource/media/upload_formats.js.erb
@@ -211,6 +211,7 @@ $(document).on('turbolinks:load', function() {
     // If editing the form, the formats requirement may have already been fulfilled by previous uploads.
     if (window.location.href.indexOf("/edit?") > -1) {
       checkFormatsRequirement();
+      updateAcceptedFormatsMessage();
     }
 
     // Whenever a file is uploaded, check to see if it fulfills the formats requirement, and update the unallowed files message if the file is the wrong extension.


### PR DESCRIPTION
Hyrax lists previously uploaded files in the 'representative media' section of the edit form, so it wasn't necessary for me to add a partial. 

Also sneaking in a small change to update the accepted formats message on the files tab when the page loads for the edit form. 