### PR TITLE
MR-351: Assign File Set Visibility from the Media Work form

### DIFF
--- a/app/actors/hyrax/actors/file_set_actor.rb
+++ b/app/actors/hyrax/actors/file_set_actor.rb
@@ -1,0 +1,168 @@
+module Hyrax
+  module Actors
+    # Actions are decoupled from controller logic so that they may be called from a controller or a background job.
+    class FileSetActor
+      include Lockable
+      attr_reader :file_set, :user, :attributes
+
+      def initialize(file_set, user)
+        @file_set = file_set
+        @user = user
+      end
+
+      # @!group Asynchronous Operations
+
+      # Spawns asynchronous IngestJob unless ingesting from URL
+      # Called from FileSetsController, AttachFilesToWorkJob, IngestLocalFileJob, ImportUrlJob
+      # @param [Hyrax::UploadedFile, File] file the file uploaded by the user
+      # @param [Symbol, #to_s] relation
+      # @return [IngestJob, FalseClass] false on failure, otherwise the queued job
+      def create_content(file, relation = :original_file, from_url: false)
+        # If the file set doesn't have a title or label assigned, set a default.
+        file_set.label ||= label_for(file)
+        file_set.title = [file_set.label] if file_set.title.blank?
+        return false unless file_set.save # Need to save to get an id
+        if from_url
+          # If ingesting from URL, don't spawn an IngestJob; instead
+          # reach into the FileActor and run the ingest with the file instance in
+          # hand. Do this because we don't have the underlying UploadedFile instance
+          file_actor = build_file_actor(relation)
+          file_actor.ingest_file(wrapper!(file: file, relation: relation))
+          # Copy visibility and permissions from parent (work) to
+          # FileSets even if they come in from BrowseEverything
+          VisibilityCopyJob.perform_later(file_set.parent)
+          InheritPermissionsJob.perform_later(file_set.parent)
+        else
+          IngestJob.perform_later(wrapper!(file: file, relation: relation))
+        end
+      end
+
+      # Spawns asynchronous IngestJob with user notification afterward
+      # @param [Hyrax::UploadedFile, File, ActionDigest::HTTP::UploadedFile] file the file uploaded by the user
+      # @param [Symbol, #to_s] relation
+      # @return [IngestJob] the queued job
+      def update_content(file, relation = :original_file)
+        IngestJob.perform_later(wrapper!(file: file, relation: relation), notification: true)
+      end
+
+      # @!endgroup
+
+      # Adds the appropriate metadata, visibility and relationships to file_set
+      # @note In past versions of Hyrax this method did not perform a save because it is mainly used in conjunction with
+      #   create_content, which also performs a save.  However, due to the relationship between Hydra::PCDM objects,
+      #   we have to save both the parent work and the file_set in order to record the "metadata" relationship between them.
+      # @param [Hash] file_set_params specifying the visibility, lease and/or embargo of the file set.
+      #   Without visibility, embargo_release_date or lease_expiration_date, visibility will be copied from the parent.
+      def create_metadata(file_set_params = {})
+        file_set.depositor = depositor_id(user)
+        now = TimeService.time_in_utc
+        file_set.date_uploaded = now
+        file_set.date_modified = now
+        file_set.creator = [user.user_key]
+        if assign_visibility?(file_set_params)
+          env = Actors::Environment.new(file_set, ability, file_set_params)
+          CurationConcern.file_set_create_actor.create(env)
+        end
+        yield(file_set) if block_given?
+      end
+
+      # Adds a FileSet to the work using ore:Aggregations.
+      # Locks to ensure that only one process is operating on the list at a time.
+      def attach_to_work(work, file_set_params = {})
+        acquire_lock_for(work.id) do
+          # Ensure we have an up-to-date copy of the members association, so that we append to the end of the list.
+          work.reload unless work.new_record?
+          file_set.visibility = work.visibility unless assign_visibility?(file_set_params)
+          work.ordered_members << file_set
+          work.representative = file_set if work.representative_id.blank?
+          work.thumbnail = file_set if work.thumbnail_id.blank?
+          # Save the work so the association between the work and the file_set is persisted (head_id)
+          # NOTE: the work may not be valid, in which case this save doesn't do anything.
+          work.save
+          Hyrax.config.callback.run(:after_create_fileset, file_set, user)
+        end
+      end
+      alias attach_file_to_work attach_to_work
+      deprecation_deprecate attach_file_to_work: "use attach_to_work instead"
+
+      # @param [String] revision_id the revision to revert to
+      # @param [Symbol, #to_sym] relation
+      # @return [Boolean] true on success, false otherwise
+      def revert_content(revision_id, relation = :original_file)
+        return false unless build_file_actor(relation).revert_to(revision_id)
+        Hyrax.config.callback.run(:after_revert_content, file_set, user, revision_id)
+        true
+      end
+
+      def update_metadata(attributes)
+        env = Actors::Environment.new(file_set, ability, attributes)
+        CurationConcern.file_set_update_actor.update(env)
+      end
+
+      def destroy
+        unlink_from_work
+        file_set.destroy
+        Hyrax.config.callback.run(:after_destroy, file_set.id, user)
+      end
+
+      class_attribute :file_actor_class
+      self.file_actor_class = Hyrax::Actors::FileActor
+
+      private
+
+        def ability
+          @ability ||= ::Ability.new(user)
+        end
+
+        def build_file_actor(relation)
+          file_actor_class.new(file_set, relation, user)
+        end
+
+        # uses create! because object must be persisted to serialize for jobs
+        def wrapper!(file:, relation:)
+          JobIoWrapper.create_with_varied_file_handling!(user: user, file: file, relation: relation, file_set: file_set)
+        end
+
+        # For the label, use the original_filename or original_name if it's there.
+        # If the file was imported via URL, parse the original filename.
+        # If all else fails, use the basename of the file where it sits.
+        # @note This is only useful for labeling the file_set, because of the recourse to import_url
+        def label_for(file)
+          if file.is_a?(Hyrax::UploadedFile) # filename not present for uncached remote file!
+            file.uploader.filename.present? ? file.uploader.filename : File.basename(Addressable::URI.parse(file.file_url).path)
+          elsif file.respond_to?(:original_name) # e.g. Hydra::Derivatives::IoDecorator
+            file.original_name
+          elsif file_set.import_url.present?
+            # This path is taken when file is a Tempfile (e.g. from ImportUrlJob)
+            File.basename(Addressable::URI.parse(file_set.import_url).path)
+          else
+            File.basename(file)
+          end
+        end
+
+        def assign_visibility?(file_set_params = {})
+          !((file_set_params || {}).keys.map(&:to_s) & %w[visibility embargo_release_date lease_expiration_date]).empty?
+        end
+
+        # replaces file_set.apply_depositor_metadata(user)from hydra-access-controls so depositor doesn't automatically get edit access
+        def depositor_id(depositor)
+          depositor.respond_to?(:user_key) ? depositor.user_key : depositor
+        end
+
+        # Must clear the fileset from the thumbnail_id, representative_id and rendering_ids fields on the work
+        #   and force it to be re-solrized.
+        # Although ActiveFedora clears the children nodes it leaves those fields in Solr populated.
+        # rubocop:disable Metrics/CyclomaticComplexity
+        def unlink_from_work
+          work = file_set.parent
+          return unless work && (work.thumbnail_id == file_set.id || work.representative_id == file_set.id || work.rendering_ids.include?(file_set.id))
+          work.thumbnail = nil if work.thumbnail_id == file_set.id
+          work.representative = nil if work.representative_id == file_set.id
+          work.rendering_ids -= [file_set.id]
+          work.save!
+        end
+      # rubocop:enable Metrics/AbcSize
+      # rubocop:enable Metrics/CyclomaticComplexity
+    end
+  end
+end

--- a/app/actors/hyrax/actors/file_set_actor.rb
+++ b/app/actors/hyrax/actors/file_set_actor.rb
@@ -60,7 +60,7 @@ module Hyrax
         file_set.date_modified = now
         file_set.creator = [user.user_key]
         if assign_visibility?(file_set_params)
-
+          
           env = Actors::Environment.new(file_set, ability, file_set_params)
           CurationConcern.file_set_create_actor.create(env)
         end
@@ -80,7 +80,6 @@ module Hyrax
             file_set.visibility = 'restricted'
           else
             file_set.visibility = work.visibility unless assign_visibility?(file_set_params)
-            # file_set.visibility = work.visibility
           end
           work.ordered_members << file_set
           work.representative = file_set if work.representative_id.blank?

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -26,4 +26,5 @@
 //= require morphosource/ms_app
 //= require morphosource/ms_editor
 //= require morphosource/media/upload_formats
+//= require morphosource/media/file_set_visibility
 //= require morphosource/ms_save_work_control

--- a/app/controllers/hyrax/media_controller.rb
+++ b/app/controllers/hyrax/media_controller.rb
@@ -12,6 +12,8 @@ module Hyrax
     # Use this line if you want to use a custom presenter
     self.show_presenter = Hyrax::MediaPresenter
 
+    before_action :set_fileset_visibility, only: [:create, :update]
+
     # Overriding WorksControllerBehavior to add file format validation
     # Could not do this as an ActiveModel validation because new file uploads are not added until after create
     def create
@@ -76,6 +78,14 @@ module Hyrax
       def file_formats_valid?
         validate_file_formats
         curation_concern.errors.empty? ? true : false
+      end
+
+      def set_fileset_visibility
+        if params["media"]["fileset_visibility"] == "restricted"
+          curation_concern.fileset_visibility = ["restricted"]
+        else
+          curation_concern.fileset_visibility = [""]
+        end
       end
   end
 end

--- a/app/forms/morphosource/form_methods.rb
+++ b/app/forms/morphosource/form_methods.rb
@@ -2,7 +2,7 @@ module Morphosource
   # Adds methods to add work to parent work
   module FormMethods
 
-    delegate :work_parents_attributes=, to: :model
+    delegate :work_parents_attributes=, :fileset_visibility, to: :model
 
     def self.included(base)
       base.extend(FormMethods)

--- a/app/indexers/media_indexer.rb
+++ b/app/indexers/media_indexer.rb
@@ -9,10 +9,9 @@ class MediaIndexer < Morphosource::WorkIndexer
   # this behavior
   include Hyrax::IndexesLinkedMetadata
 
-  # Uncomment this block if you want to add custom indexing behavior:
-  # def generate_solr_document
-  #  super.tap do |solr_doc|
-  #    solr_doc['my_custom_field_ssim'] = object.my_custom_property
-  #  end
-  # end
+  def generate_solr_document
+   super.tap do |solr_doc|
+     solr_doc['file_set_visibilities_ssim'] = object.file_set_visibilities
+   end
+  end
 end

--- a/app/models/concerns/morphosource/media_metadata.rb
+++ b/app/models/concerns/morphosource/media_metadata.rb
@@ -71,6 +71,9 @@ module Morphosource
     index.as :stored_searchable
     end
 
+    # Stores user-selected default setting for file set visibility
+    property :fileset_visibility, predicate: ::RDF::URI.new("https://www.morphosource.org/terms/filesetVisibility")
+
     # -- Media type-specific metadata --
 
     # ImageStack fields

--- a/app/models/concerns/morphosource/media_metadata.rb
+++ b/app/models/concerns/morphosource/media_metadata.rb
@@ -2,111 +2,111 @@ module Morphosource
   # Module to define core (non-modality specific) metadata properties for
   # media works
   module MediaMetadata
-	extend ActiveSupport::Concern
+  extend ActiveSupport::Concern
 
-	included do
-	  # -- Core metadata --
+  included do
+    # -- Core metadata --
 
-	  # Required select values
-	  property :modality, predicate: ::RDF::URI.new("https://www.morphosource.org/terms/modality3D") do |index|
-	  	index.as :stored_searchable, :facetable
-	  end
+    # Required select values
+    property :modality, predicate: ::RDF::URI.new("https://www.morphosource.org/terms/modality3D") do |index|
+      index.as :stored_searchable, :facetable
+    end
 
-	  property :media_type, predicate: ::RDF::URI.new("http://rs.tdwg.org/ac/terms/subtypeLiteral") do |index|
-		index.as :stored_searchable, :facetable
-	  end
+    property :media_type, predicate: ::RDF::URI.new("http://rs.tdwg.org/ac/terms/subtypeLiteral") do |index|
+    index.as :stored_searchable, :facetable
+    end
 
-	  # Optional select values
-	  property :side, predicate: ::RDF::URI.new("http://rs.tdwg.org/ac/terms/comments") do |index|
-		index.as :stored_searchable, :facetable
-	  end
+    # Optional select values
+    property :side, predicate: ::RDF::URI.new("http://rs.tdwg.org/ac/terms/comments") do |index|
+    index.as :stored_searchable, :facetable
+    end
 
-	  # Optional free text values
-	  property :part, predicate: ::RDF::URI.new("http://rs.tdwg.org/ac/terms/subjectPart") do |index|
-		index.as :stored_searchable
-	  end
+    # Optional free text values
+    property :part, predicate: ::RDF::URI.new("http://rs.tdwg.org/ac/terms/subjectPart") do |index|
+    index.as :stored_searchable
+    end
 
-	  property :orientation, predicate: ::RDF::URI.new("http://rs.tdwg.org/ac/terms/subjectOrientation") do |index|
-		index.as :stored_searchable
-	  end
+    property :orientation, predicate: ::RDF::URI.new("http://rs.tdwg.org/ac/terms/subjectOrientation") do |index|
+    index.as :stored_searchable
+    end
 
-	  property :funding, predicate: ::RDF::URI.new("http://rs.tdwg.org/ac/terms/fundingAttribution") do |index|
-		index.as :stored_searchable
-	  end
+    property :funding, predicate: ::RDF::URI.new("http://rs.tdwg.org/ac/terms/fundingAttribution") do |index|
+    index.as :stored_searchable
+    end
 
-	  property :cite_as, predicate: ::RDF::URI.new("http://ns.adobe.com/photoshop/1.0/Credit") do |index|
-		index.as :stored_searchable
-	  end
+    property :cite_as, predicate: ::RDF::URI.new("http://ns.adobe.com/photoshop/1.0/Credit") do |index|
+    index.as :stored_searchable
+    end
 
-	  property :rights_holder, predicate: ::RDF::URI.new("http://ns.adobe.com/xap/1.0/rights/Owner") do |index|
-		index.as :stored_searchable
-	  end
+    property :rights_holder, predicate: ::RDF::URI.new("http://ns.adobe.com/xap/1.0/rights/Owner") do |index|
+    index.as :stored_searchable
+    end
 
-	  property :agreement_uri, predicate: ::RDF::URI.new("http://ns.adobe.com/xap/1.0/rights/UsageTerms") do |index|
-		index.as :stored_searchable
-	  end
+    property :agreement_uri, predicate: ::RDF::URI.new("http://ns.adobe.com/xap/1.0/rights/UsageTerms") do |index|
+    index.as :stored_searchable
+    end
 
-	  # Fields not present on edit/show form
-	  property :legacy_media_file_id, predicate: ::RDF::URI.new("http://rs.tdwg.org/ac/terms/providerManagedID") do |index|
-		index.as :stored_searchable
-	  end
+    # Fields not present on edit/show form
+    property :legacy_media_file_id, predicate: ::RDF::URI.new("http://rs.tdwg.org/ac/terms/providerManagedID") do |index|
+    index.as :stored_searchable
+    end
 
-	  property :legacy_media_group_id, predicate: ::RDF::URI.new("http://rs.tdwg.org/ac/terms/IDofContainingCollection") do |index|
-		index.as :stored_searchable
-	  end
+    property :legacy_media_group_id, predicate: ::RDF::URI.new("http://rs.tdwg.org/ac/terms/IDofContainingCollection") do |index|
+    index.as :stored_searchable
+    end
 
-	  property :uuid, predicate: ::RDF::URI.new("https://www.morphosource.org/terms/mediaUUID") do |index|
-		index.as :stored_searchable
-	  end
+    property :uuid, predicate: ::RDF::URI.new("https://www.morphosource.org/terms/mediaUUID") do |index|
+    index.as :stored_searchable
+    end
 
-	  property :ark, predicate: ::RDF::URI.new("https://www.morphosource.org/terms/mediaARK") do |index|
-		index.as :stored_searchable
-	  end
+    property :ark, predicate: ::RDF::URI.new("https://www.morphosource.org/terms/mediaARK") do |index|
+    index.as :stored_searchable
+    end
 
-	  property :doi, predicate: ::RDF::URI.new("https://www.morphosource.org/terms/mediaDOI") do |index|
-		index.as :stored_searchable
-	  end
+    property :doi, predicate: ::RDF::URI.new("https://www.morphosource.org/terms/mediaDOI") do |index|
+    index.as :stored_searchable
+    end
 
-	  property :available, predicate: ::RDF::Vocab::DC.available do |index|
-		index.as :stored_searchable
-	  end
+    property :available, predicate: ::RDF::Vocab::DC.available do |index|
+    index.as :stored_searchable
+    end
 
-	  # -- Media type-specific metadata --
+    # -- Media type-specific metadata --
 
-	  # ImageStack fields
-	  property :number_of_images_in_set, predicate: ::RDF::URI.new("https://www.morphosource.org/terms/dicomNumberOfSeriesRelatedInstances"), multiple: false do |index|
-		index.as :stored_searchable
-	  end
+    # ImageStack fields
+    property :number_of_images_in_set, predicate: ::RDF::URI.new("https://www.morphosource.org/terms/dicomNumberOfSeriesRelatedInstances"), multiple: false do |index|
+    index.as :stored_searchable
+    end
 
-	  # CTImageStack fields
-	  property :x_spacing, predicate: ::RDF::URI.new("https://www.morphosource.org/terms/dicomPixelSpacingWidth") do |index|
-		index.as :stored_searchable
-	  end
+    # CTImageStack fields
+    property :x_spacing, predicate: ::RDF::URI.new("https://www.morphosource.org/terms/dicomPixelSpacingWidth") do |index|
+    index.as :stored_searchable
+    end
 
-	  property :y_spacing, predicate: ::RDF::URI.new("https://www.morphosource.org/terms/dicomPixelSpacingHeight") do |index|
-		index.as :stored_searchable
-	  end
+    property :y_spacing, predicate: ::RDF::URI.new("https://www.morphosource.org/terms/dicomPixelSpacingHeight") do |index|
+    index.as :stored_searchable
+    end
 
-	  property :z_spacing, predicate: ::RDF::URI.new("https://www.morphosource.org/terms/dicomSpacingBetweenSlices") do |index|
-		index.as :stored_searchable
-	  end
+    property :z_spacing, predicate: ::RDF::URI.new("https://www.morphosource.org/terms/dicomSpacingBetweenSlices") do |index|
+    index.as :stored_searchable
+    end
 
-	  # PhotogrammetryImageStack fields
+    # PhotogrammetryImageStack fields
     property :scale_bar, predicate: ::RDF::URI.new("https://www.morphosource.org/terms/scaleBar") do |index|
-		index.as :stored_searchable
-	  end
+    index.as :stored_searchable
+    end
 
-	  # Mesh and CTImageStack field
-	  property :unit, predicate: ::RDF::URI.new("https://www.morphosource.org/terms/ACExt/units") do |index|
-		index.as :stored_searchable, :facetable
-	  end
+    # Mesh and CTImageStack field
+    property :unit, predicate: ::RDF::URI.new("https://www.morphosource.org/terms/ACExt/units") do |index|
+    index.as :stored_searchable, :facetable
+    end
 
-	  # Mesh field
-	   property :map_type, predicate: ::RDF::URI.new("https://www.morphosource.org/terms/mapType") do |index|
-		index.as :stored_searchable, :facetable
-	  end
+    # Mesh field
+     property :map_type, predicate: ::RDF::URI.new("https://www.morphosource.org/terms/mapType") do |index|
+    index.as :stored_searchable, :facetable
+    end
 
 
-	end
+  end
   end
 end

--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -15,4 +15,31 @@ class Media < Morphosource::Works::Base
   # This must be included at the end, because it finalizes the metadata
   # schema (by adding accepts_nested_attributes)
   include ::Hyrax::BasicMetadata
+
+  # array of all visibilities that apply to the file sets of a Media work
+  # used to populate File Visibility column in dashboard works list
+  def file_set_visibilities
+
+    all_visibilities = [
+      Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC,
+      Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED,
+      Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_EMBARGO,
+      Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_LEASE,
+      Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE ]
+
+    file_visibilities = []
+
+    file_set_ids.each do |id|
+      file = FileSet.find(id)
+      if file.embargo_id.present?
+        file_visibilities << "embargo"
+      elsif file.lease_id.present?
+        file_visibilities << "lease"
+      else
+        file_visibilities << file.visibility
+      end
+    end
+    # order unique visibilities in the order that they appear on the work form.
+    all_visibilities & file_visibilities
+  end
 end

--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -19,7 +19,7 @@ class Media < Morphosource::Works::Base
   # array of all visibilities that apply to the file sets of a Media work
   # used to populate File Visibility column in dashboard works list
   def file_set_visibilities
-
+    
     all_visibilities = [
       Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC,
       Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED,
@@ -29,12 +29,11 @@ class Media < Morphosource::Works::Base
 
     file_visibilities = []
 
-    file_set_ids.each do |id|
-      file = FileSet.find(id)
+    file_sets.each do |file|
       if file.embargo_id.present?
-        file_visibilities << "embargo"
+        file_visibilities << Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_EMBARGO
       elsif file.lease_id.present?
-        file_visibilities << "lease"
+        file_visibilities << Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_LEASE
       else
         file_visibilities << file.visibility
       end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -55,6 +55,11 @@ class SolrDocument
     self[Solrizer.solr_name('title', :stored_sortable)]
   end
 
+  # Add custom column to dashboard works list
+  def file_set_visibilities
+    self["file_set_visibilities_ssim"]
+  end
+
   # Media Fields
   def agreement_uri
     self[Solrizer.solr_name('agreement_uri', :stored_searchable)]
@@ -206,11 +211,11 @@ class SolrDocument
   def bits_per_sample
     self[Solrizer.solr_name('bits_per_sample', :stored_searchable)]
   end
-  
+
   def color_space
     self[Solrizer.solr_name('color_space', :stored_searchable)]
   end
-  
+
   def compression
     self[Solrizer.solr_name('compression', :stored_searchable)]
   end
@@ -498,7 +503,7 @@ class SolrDocument
   def edges_per_face
     self[Solrizer.solr_name('edges_per_face', :stored_searchable)]
   end
-  
+
   def color_format
     self[Solrizer.solr_name('color_format', :stored_searchable)]
   end

--- a/app/views/hyrax/base/_file_set_visibility.html.erb
+++ b/app/views/hyrax/base/_file_set_visibility.html.erb
@@ -1,0 +1,34 @@
+<!--
+Add Default File Visibility section to Media Works
+  - If editing the work, adds 'selected_fileset_visibility' class to previously selected file visibility radio input used by file_set_visibility.js.erb.
+-->
+
+<fieldset>
+  <legend class="legend-save-work">Default File Visibility</legend>
+  <ul class="visibility file-set-visibility" id="fs-visibility">
+    <li class="radio">
+      <% f.object.model.fileset_visibility == ['restricted'] ? selected = "" : selected = "selected_fileset_visibility" %>
+      <label>
+        <%= f.radio_button :fileset_visibility, 'default', class: selected %>
+        <%= t('morphosource.file_visibility.default.note_html') %>
+      </label>
+    </li>
+
+    <li class="radio">
+      <% f.object.model.fileset_visibility == ['restricted'] ? selected = "selected_fileset_visibility" : selected = "" %>
+      <label>
+        <%= f.radio_button :fileset_visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE, data: { 'target':'#collapseFilesetRestricted', 'toggle':'collapse'}, class: selected %>
+        <%= visibility_badge(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE) %>
+        <br/>
+        <%= t('morphosource.file_visibility.restricted.note_html') %>
+        <div class="collapse" id="collapseFilesetRestricted">
+          <% if f.object.persisted? %>
+            <%= t('morphosource.file_visibility.restricted.edit_work_warning_html') %>
+          <% else %>
+            <%= t('morphosource.file_visibility.restricted.new_work_warning_html') %>
+          <% end %>
+        </div>
+      </label>
+    </li>
+  </ul>
+</fieldset>

--- a/app/views/hyrax/base/_form_visibility_component.html.erb
+++ b/app/views/hyrax/base/_form_visibility_component.html.erb
@@ -1,0 +1,70 @@
+<% if f.object.embargo_release_date %>
+  <%= render 'form_permission_under_embargo', f: f %>
+<% elsif f.object.lease_expiration_date %>
+  <%= render 'form_permission_under_lease', f: f %>
+<% else %>
+    <fieldset>
+      <legend class="legend-save-work">Visibility</legend>
+      <ul class="visibility">
+        <li class="radio">
+          <label>
+            <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC, data: { 'target': '#collapsePublic' } %>
+            <%= visibility_badge(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC) %>
+            <br />
+            <%= t('hyrax.visibility.open.note_html', type: f.object.human_readable_type) %>
+            <div class="collapse" id="collapsePublic">
+              <%= t('hyrax.visibility.open.warning_html', label: visibility_badge(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC)) %>
+            </div>
+          </label>
+        </li>
+        <li class="radio">
+          <label>
+            <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED %>
+            <%= visibility_badge(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED) %>
+            <br />
+            <%= t('hyrax.visibility.authenticated.note_html', institution: institution_name) %>
+          </label>
+        </li>
+        <li class="radio">
+          <label>
+            <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_EMBARGO, data: { 'target': '#collapseEmbargo' } %>
+            <%= visibility_badge(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_EMBARGO) %>
+            <br />
+            <%= t('hyrax.visibility.embargo.note_html') %>
+            <div class="collapse" id="collapseEmbargo">
+              <div class="form-inline">
+                <%= f.input :visibility_during_embargo, wrapper: :inline, collection: visibility_options(:restrict), include_blank: false %>
+                <%= t('hyrax.works.form.visibility_until') %>
+                <%= f.date_field :embargo_release_date, wrapper: :inline, value: f.object.embargo_release_date || Date.tomorrow, class: 'datepicker form-control' %>
+                <%= f.input :visibility_after_embargo, wrapper: :inline, collection: visibility_options(:loosen), include_blank: false %>
+              </div>
+            </div>
+          </label>
+        </li>
+        <li class="radio">
+          <label>
+            <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_LEASE, data: { 'target': '#collapseLease' } %>
+            <%= visibility_badge(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_LEASE) %>
+            <br />
+            <%= t('hyrax.visibility.lease.note_html') %>
+            <div class="collapse" id="collapseLease">
+              <div class="form-inline">
+                <%= f.input :visibility_during_lease, wrapper: :inline, collection: visibility_options(:loosen), include_blank: false %>
+                <%= t('hyrax.works.form.visibility_until') %>
+                <%= f.date_field :lease_expiration_date, wrapper: :inline, value: f.object.lease_expiration_date || Date.tomorrow, class: 'datepicker form-control' %>
+                <%= f.input :visibility_after_lease, wrapper: :inline, collection: visibility_options(:restrict), include_blank: false %>
+              </div>
+            </div>
+          </label>
+        </li>
+        <li class="radio">
+          <label>
+            <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE %>
+            <%= visibility_badge(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE) %>
+            <br />
+            <%= t('hyrax.visibility.restricted.note_html') %>
+          </label>
+        </li>
+      </ul>
+    </fieldset>
+<% end %>

--- a/app/views/hyrax/base/_form_visibility_component.html.erb
+++ b/app/views/hyrax/base/_form_visibility_component.html.erb
@@ -1,10 +1,20 @@
 <% if f.object.embargo_release_date %>
   <%= render 'form_permission_under_embargo', f: f %>
+    <% if f.object.model_name.name == 'Media' %>
+      <%= render 'file_set_visibility', f: f %>
+    <% end %>
 <% elsif f.object.lease_expiration_date %>
   <%= render 'form_permission_under_lease', f: f %>
+    <% if f.object.model_name.name == 'Media' %>
+      <%= render 'file_set_visibility', f: f %>
+    <% end %>
 <% else %>
     <fieldset>
-      <legend class="legend-save-work">Visibility</legend>
+      <% if f.object.model_name.name == 'Media' %>
+        <legend class="legend-save-work">Work Visibility</legend>
+      <% else %>
+        <legend class="legend-save-work">Visibility</legend>
+      <% end %>
       <ul class="visibility">
         <li class="radio">
           <label>
@@ -67,4 +77,8 @@
         </li>
       </ul>
     </fieldset>
+    <br />
+    <% if f.object.model_name.name == 'Media' %>
+     <%= render 'file_set_visibility', f: f %>
+   <% end %>
 <% end %>

--- a/app/views/hyrax/my/works/_default_group.html.erb
+++ b/app/views/hyrax/my/works/_default_group.html.erb
@@ -1,0 +1,18 @@
+<table class="table table-striped works-list">
+  <caption class="sr-only"><%= t("hyrax.dashboard.my.sr.listing") %> <%= application_name %></caption>
+  <thead>
+  <tr>
+    <th class="check-all"><label for="check_all" class="sr-only"><%= t("hyrax.dashboard.my.sr.check_all_label") %></label><%= render_check_all %></th>
+    <th><%= t("hyrax.dashboard.my.heading.title") %></th>
+    <th><%= t("hyrax.dashboard.my.heading.date_uploaded") %></th>
+    <th><%= t("hyrax.dashboard.my.heading.highlighted") %></th>
+    <th><%= t("hyrax.dashboard.my.heading.visibility") %></th>
+    <th><%= t("hyrax.dashboard.my.heading.action") %></th>
+  </tr>
+  </thead>
+  <tbody>
+  <% docs.each_with_index do |document, counter| %>
+      <%= render 'list_works', document: document, counter: counter, presenter: Hyrax::WorkShowPresenter.new(document, current_ability) %>
+  <% end %>
+  </tbody>
+</table>

--- a/app/views/hyrax/my/works/_default_group.html.erb
+++ b/app/views/hyrax/my/works/_default_group.html.erb
@@ -1,3 +1,4 @@
+
 <table class="table table-striped works-list">
   <caption class="sr-only"><%= t("hyrax.dashboard.my.sr.listing") %> <%= application_name %></caption>
   <thead>
@@ -7,6 +8,7 @@
     <th><%= t("hyrax.dashboard.my.heading.date_uploaded") %></th>
     <th><%= t("hyrax.dashboard.my.heading.highlighted") %></th>
     <th><%= t("hyrax.dashboard.my.heading.visibility") %></th>
+    <th><%= t("morphosource.dashboard.my.heading.file_visibility") %></th>
     <th><%= t("hyrax.dashboard.my.heading.action") %></th>
   </tr>
   </thead>

--- a/app/views/hyrax/my/works/_list_works.html.erb
+++ b/app/views/hyrax/my/works/_list_works.html.erb
@@ -1,0 +1,40 @@
+<tr id="document_<%= document.id %>">
+
+  <td>
+    <label for="batch_document_<%= document.id %>" class="sr-only"><%= t("hyrax.dashboard.my.sr.batch_checkbox") %></label>
+    <%= render 'hyrax/batch_select/add_button', document: document %>&nbsp;
+  </td>
+
+  <td>
+    <div class='media'>
+      <%= link_to [main_app, document], class: 'media-left', 'aria-hidden' => true do %>
+        <%= render_thumbnail_tag document, { class: 'hidden-xs file_listing_thumbnail' }, { suppress_link: true } %>
+      <% end %>
+
+      <div class='media-body'>
+        <div class='media-heading'>
+
+          <%= link_to [main_app, document], id: "src_copy_link#{document.id}", class: 'document-title' do %>
+            <span class="sr-only">
+              <%= t("hyrax.dashboard.my.sr.show_label") %>
+            </span>
+            <%= document.title_or_label %>
+          <% end %>
+
+          <br />
+          <%= render_collection_links(document) %>
+
+        </div>
+      </div>
+    </div>
+  </td>
+
+  <td class="date"><%= document.date_uploaded %></td>
+  <td class='text-center'>
+    <span class="fa <%= current_user.trophies.where(work_id: document.id).exists? ? 'fa-star highlighted-work' : 'fa-star-o trophy-off' %>" aria-hidden="true"></span></td>
+  <td><%= render_visibility_link document %></td>
+
+  <td>
+    <%= render 'work_action_menu', document: document %>
+  </td>
+</tr>

--- a/app/views/hyrax/my/works/_list_works.html.erb
+++ b/app/views/hyrax/my/works/_list_works.html.erb
@@ -1,5 +1,4 @@
 <tr id="document_<%= document.id %>">
-
   <td>
     <label for="batch_document_<%= document.id %>" class="sr-only"><%= t("hyrax.dashboard.my.sr.batch_checkbox") %></label>
     <%= render 'hyrax/batch_select/add_button', document: document %>&nbsp;
@@ -33,7 +32,16 @@
   <td class='text-center'>
     <span class="fa <%= current_user.trophies.where(work_id: document.id).exists? ? 'fa-star highlighted-work' : 'fa-star-o trophy-off' %>" aria-hidden="true"></span></td>
   <td><%= render_visibility_link document %></td>
-
+  <td>
+    <div style="display:flex; flex-direction: column; justify-content: space-around; align-items: flex-start;">
+      <% unless document.file_set_visibilities.nil? %>
+        <% document.file_set_visibilities.each do |visibility| %>
+          <%= visibility_badge(visibility) %>
+          <div style="height: 3px;"></div>
+        <% end %>
+      <% end %>
+    </div>
+  </td>
   <td>
     <%= render 'work_action_menu', document: document %>
   </td>

--- a/config/locales/morphosource.en.yml
+++ b/config/locales/morphosource.en.yml
@@ -5,6 +5,13 @@ en:
         title: 'Your work must have a title.'
         vouchered: 'Missing value in vouchered? field. Does the object you are adding still physically exist?'
     fallback_object_title: "%{voucher} object contributed by %{user}"
+    file_visibility:
+      default:
+        note_html: Use the same visibility settings as above.
+      restricted:
+        note_html: Keep attached files to myself with option to share.
+        new_work_warning_html: '<p> <strong>Please note</strong>, this determines the initial visibility setting for files added to this work. Visibility settings for individual files can be changed manually after this work is saved. </p>'
+        edit_work_warning_html: '<p> <strong>Please note</strong>, this determines the initial visibility setting for <strong>NEW</strong> files added to this work. Visibility settings for individual files can be changed manually after this work is saved. </p>'
     media:
       format_labels:
         image: 'Image'

--- a/config/locales/morphosource.en.yml
+++ b/config/locales/morphosource.en.yml
@@ -1,5 +1,9 @@
 en:
   morphosource:
+    dashboard:
+      my:
+        heading:
+          file_visibility: 'File Visibility'
     validation:
       missing:
         title: 'Your work must have a title.'

--- a/lib/assets/javascripts/morphosource/media/file_set_visibility.js.erb
+++ b/lib/assets/javascripts/morphosource/media/file_set_visibility.js.erb
@@ -1,0 +1,39 @@
+// if editing a record, file_set_visibility partial adds 'selected_fileset_visibility' class to radio button input with previously selected default file visibility.
+function initial_value() {
+  let fileVisibilityDefault = $('#media_fileset_visibility_default');
+  let fileVisibilityPrivate = $('#media_fileset_visibility_restricted');
+  if (fileVisibilityPrivate.hasClass('selected_fileset_visibility')) {
+    fileVisibilityPrivate.prop("checked", true);
+  }
+  else {
+    fileVisibilityDefault.prop("checked", true);
+  }
+}
+
+// If work visibility 'Private' is selected, then hide the 'Private' radio button under Default File Visibility.
+function file_visibility_options() {
+  let workVisibilityPrivate = $('#media_visibility_restricted');
+  let fileVisibilityDefault = $('#media_fileset_visibility_default');
+  let fileVisibilityPrivateLi = $('#media_fileset_visibility_restricted').closest("li");
+
+  if (workVisibilityPrivate.is(':checked')) {
+    fileVisibilityPrivateLi.addClass('hidden');
+    fileVisibilityDefault.prop("checked", true);
+  }
+  else {
+    fileVisibilityPrivateLi.removeClass('hidden');
+  }
+}
+
+$(document).on('turbolinks:load', function() {
+  if ($('form[id*="media"]').length) {
+    initial_value();
+    file_visibility_options();
+  }
+});
+
+$(document).on('change', '.set-access-controls', function() {
+  if ($('form[id*="media"]').length) {
+    file_visibility_options();
+  }
+});

--- a/spec/actors/hyrax/actors/file_set_actor_spec.rb
+++ b/spec/actors/hyrax/actors/file_set_actor_spec.rb
@@ -1,0 +1,82 @@
+require 'redlock'
+require 'rails_helper'
+
+RSpec.describe Hyrax::Actors::FileSetActor do
+  include ActionDispatch::TestProcess
+  let(:user)          { User.new(id: 1) }
+  let(:work)          { Media.new(title: ["Test Media Work"]) }
+
+  describe "#attach_to_work" do
+    context 'the work visibility is public' do
+      let(:file_set)      { FileSet.create }
+      let(:actor)         { described_class.new(file_set, user) }
+
+      before do
+        allow(actor).to receive(:acquire_lock_for).and_yield
+        work.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+      end
+
+      context 'when the user wants the same visibility for the work and files' do
+        before do
+          work.fileset_visibility = [""]
+        end
+        it 'copies file_set visibility from the parent' do
+          actor.attach_to_work(work)
+          expect(file_set.reload.visibility).to eq(work.visibility)
+        end
+      end
+
+      context 'when the user wants the file visibility to be private' do
+        before do
+          work.fileset_visibility = ["restricted"]
+        end
+        it 'assigns a private visibility to the file' do
+          actor.attach_to_work(work)
+          expect(file_set.reload.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+        end
+      end
+    end
+
+    context 'the work visibility is embargoed' do
+      let (:file_set_params) { {:visibility=>"restricted",
+                                :visibility_during_lease=>"open", :visibility_after_lease=>"restricted", :lease_expiration_date=> (Time.zone.today + 2).to_s,
+                                :embargo_release_date=> (Time.zone.today + 2).to_s, :visibility_during_embargo=>"restricted", :visibility_after_embargo=>"open"} }
+      let(:file_set)         { FileSet.create(attributes: file_set_params) }
+      let(:actor)             { described_class.new(file_set, user) }
+
+      before do
+        allow(actor).to receive(:acquire_lock_for).and_yield
+        work.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+        work.visibility_during_embargo = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+        work.visibility_after_embargo = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+        work.embargo_release_date = (Time.zone.today + 2).to_s
+      end
+
+      context 'when the user wants the same visibility for the work and files' do
+
+        before do
+          work.fileset_visibility = [""]
+        end
+
+        it 'copies file_set visibility from the parent' do
+          actor.attach_to_work(work)
+          expect(file_set.reload.visibility).to eq(work.visibility) 
+          expect(file_set.reload.embargo_id).not_to be(nil)
+        end
+      end
+
+      context 'when the user wants the file visibility to be private' do
+        before do
+          work.fileset_visibility = ["restricted"]
+          actor.attach_to_work(work)
+        end
+        it 'assigns a private visibility to the file' do
+          expect(file_set.reload.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+        end
+        it 'removes the embargo_id from the file_set' do
+          expect(file_set.reload.embargo_id).to eq(nil)
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/hyrax/media_controller_spec.rb
+++ b/spec/controllers/hyrax/media_controller_spec.rb
@@ -130,4 +130,30 @@ RSpec.describe Hyrax::MediaController do
       end
     end
   end
+
+  describe "#set_fileset_visibility" do
+    let(:work)        { Media.new(title: ["Test Media Work"]) }
+    before do
+      allow(subject).to receive(:curation_concern).and_return(work)
+    end
+
+    context 'when user selects same file visibility as the work visibility' do
+      before do
+        allow(subject).to receive(:params).and_return({"media"=> {"fileset_visibility" => "default"}})
+      end
+      it 'sets curation_concern.fileset_visibility to an array containing an empty string' do
+        subject.send(:set_fileset_visibility)
+        expect(subject.curation_concern.fileset_visibility).to match_array([""])
+      end
+    end
+    context 'when user selects private file visibility' do
+      before do
+        allow(subject).to receive(:params).and_return({"media"=> {"fileset_visibility" => "restricted"}})
+      end
+      it 'sets curation_concern.fileset_visibility to an array containing "restricted"' do
+        subject.send(:set_fileset_visibility)
+        expect(subject.curation_concern.fileset_visibility).to match_array(["restricted"])
+      end
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -71,7 +71,7 @@ RSpec.configure do |config|
 
   # config.filter_gems_from_backtrace("gem name")
 
-  # config.include FactoryBot::Syntax::Methods
+  config.include FactoryBot::Syntax::Methods
   config.include Devise::Test::ControllerHelpers, :type => :controller
 
   config.before(:suite) do


### PR DESCRIPTION
- Can assign attached file visibility to be either the same as the work or private.
- Displays associated file visibilities for each work on the dashboard work list. 