### PR TITLE
Enable viewing of DRACO-compressed GLTF 3D meshes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 
 GIT
   remote: https://github.com/JuliaWinchester/pul_uv_rails.git
-  revision: 9d014a4cfc09670446add377da632fd33c73b096
+  revision: 97cc1ea7758332d8f657ceac3b62205f13f9e151
   specs:
     pul_uv_rails (2.9)
 
@@ -899,4 +899,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.16.5
+   1.17.3

--- a/app/views/hyrax/base/_representative_media.html.erb
+++ b/app/views/hyrax/base/_representative_media.html.erb
@@ -2,7 +2,7 @@
   <% if defined?(viewer) && viewer %>
     <div class="viewer-wrapper">
       <div class="viewer">
-  		  <iframe height="100%" width="100%" src="<%= PulUvRails::UniversalViewer.viewer_src %>#?manifest=<%= main_app.polymorphic_path [main_app, :manifest, presenter], { locale: nil } %>" allowfullscreen frameborder="0"></iframe>
+  		  <iframe height="100%" width="100%" src="<%= PulUvRails::UniversalViewer.viewer_src %>#?manifest=<%= main_app.polymorphic_path [main_app, :manifest, presenter], { locale: nil } %>&config=<%= PulUvRails::UniversalViewer.config_src %>" allowfullscreen frameborder="0"></iframe>
   	  </div>
   	</div>
   <% else %>


### PR DESCRIPTION
This commit enables preview viewing of DRACO-compressed GLTF 3D meshes using the Universal Viewer, along with changes to the Ruby gem pul_uv_rails and the Javascript packages universalviewer and virtex3d. Most of the changes to enable this functionality are in these secondary packages, and are described below:

[virtex3d](https://github.com/edsilv/virtex): Virtex is the framework used by UV to view 3D media, using three.js. Changes made include connecting a DRACO loader instance to the GLTF loader instance and creating an optional initialization flag to set a DRACO decoder file location. Also, a distribution version of virtex was produced incorporating these changes as well as appropriate loader and decoder files from Three.js. The changes required for this can be seen in my [virtex fork](https://github.com/JuliaWinchester/virtex), but a pull request will be made shortly to try and get these changes incorporated into the official branch. 

[universalviewer](https://github.com/UniversalViewer/universalviewer): UV is the framework Hyrax uses to preview various media. Changes made include using my DRACO GLTF enabled fork of virtex, and adding optional JSON config file options to set a DRACO decoder path. These changes are currently located in my [DRACO GLTF enabled fork of UV](https://github.com/JuliaWinchester/universalviewer), but hopefully a pull request can eventually made to incorporate these changes into base UV. 

[pul_uv_rails](https://github.com/pulibrary/pul_uv_rails): The Ruby gem used by Hyrax to connect UV to Hyrax. Added a distribution version of UV built from my DRACO GLTF fork, a config.json file to set the DRACO decoder path in line with the UV route used by pul_uv_rails, and a Ruby gem method to provide the config.json source path. Changes can be seen [here](https://github.com/JuliaWinchester/pul_uv_rails), but hopefully eventually a pull request can be made to get these into the official branch.   