### PR TITLE
MR-411: Changing the media type doesn't uncheck the format requirement

### DIFF
--- a/lib/assets/javascripts/morphosource/ms_save_work_control.es6
+++ b/lib/assets/javascripts/morphosource/ms_save_work_control.es6
@@ -27,6 +27,7 @@ export default class MorphosourceSaveWorkControl extends SaveWorkControl {
     this.watchFormatRequirement()
     this.formChanged()
     this.addFileUploadEventListeners()
+    this.checkValidFormats()
   }
 
   // Overrides to include validateFormats requirement.
@@ -42,7 +43,6 @@ export default class MorphosourceSaveWorkControl extends SaveWorkControl {
   // Checks whether formats requirement has been fulfilled.
   // Check mark happens in upload_formats #fulfill_requirement.
   validateFormats() {
-    this.checkValidFormats();
     // Return true if not on Media Work form.
     if ($('form[id*="media"]').length == 0) {
       return true


### PR DESCRIPTION
When editing a media work that has previously added files but no new files added, the formats requirement is prevented from being unchecked when media type changes. This change checks the requirement only once during page setup instead of multiple times. 