### PR TITLE
Cache classes in development mode

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -63,5 +63,5 @@ Rails.application.configure do
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
-  config.reload_classes_only_on_change = false
+  config.reload_classes_only_on_change = true
 end


### PR DESCRIPTION
This should improve development mode slowness, and also seems to
fix "stack level too deep" errors.

The problem seems to have been that without class caching, on every
request (and particularly any one that invokes a URL helper `*_path`
method), a huge number of dynamically generated URL helper methods
for routes have to be generated, some recursively.

Setting `config.reload_classes_only_on_change = true` should get
us the benefits of setting `config.cache_classes = true`, while
also allowing for edits to be reflected live without server
restarts.