### PR TITLE
Use ActiveSupport::FileUpdateChecker in dev environment for Vagrant shared folder compatibility

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -61,7 +61,7 @@ Rails.application.configure do
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
-  config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+  config.file_watcher = ActiveSupport::FileUpdateChecker
 
   config.reload_classes_only_on_change = true
 end


### PR DESCRIPTION
Related to #110, this should fix having to restart the server to see changes inside the Vagrant environment. From @simonmchoy in Slack.

https://gist.github.com/stungeye/3d7488affff083365bfd6bfffb7eec14