### PR TITLE
MR-404: Creates a Media Cart container for media works

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,6 +9,9 @@ class ApplicationController < ActionController::Base
   include Hyrax::ThemedLayoutController
   with_themed_layout '1_column'
 
-
   protect_from_forgery with: :exception
+
+  # Blacklight discarding flash messages - see https://github.com/samvera/hyrax/issues/1596
+  skip_after_action :discard_flash_if_xhr
+
 end

--- a/app/controllers/morphosource/my/cart_items_controller.rb
+++ b/app/controllers/morphosource/my/cart_items_controller.rb
@@ -1,0 +1,83 @@
+module Morphosource
+  module My
+    class CartItemsController < Hyrax::MyController
+
+      class_attribute :create_work_presenter_class
+      self.create_work_presenter_class = Hyrax::SelectTypeListPresenter
+
+      before_action :get_curation_concern, only: [:create]
+
+      def search_builder_class
+        if cart?
+          Morphosource::My::CartItems::CartItemsSearchBuilder
+        else
+          Morphosource::My::CartItems::DownloadsSearchBuilder
+        end
+      end
+
+      def create
+        unless item_already_in_cart?(params[:work_id])
+          @item = CartItem.new({:media_cart_id => params[:media_cart_id], :work_id => params[:work_id]})
+          if @item.save!
+            flash[:notice] = 'Item Added to Cart'
+          else
+            flash[:alert] = 'Item Add Unsuccessful'
+          end
+        else
+          flash[:alert] = 'Item Already in Cart'
+        end
+        after_create_response(@curation_concern)
+      end
+
+       def index
+        @cart = cart?
+        @items = current_user.cart_items
+        super
+        @count_text = count_text
+        render 'index'
+      end
+
+      def destroy
+        @item = CartItem.find(params[:id])
+        if @item.destroy
+          flash[:notice] = 'Item Removed from Cart'
+        else
+          flash[:alert] = 'Item Remove Unsuccessful'
+        end
+        redirect_to main_app.my_cart_path
+      end
+
+       private
+
+        def cart?
+          request.original_fullpath.include? '/dashboard/my/cart'
+        end
+
+        def works_in_cart
+          current_user.work_ids_in_cart
+        end
+
+        def item_already_in_cart?(work)
+          works_in_cart.include? work
+        end
+
+        def after_create_response(curation_concern)
+          respond_to do |format|
+            format.html { redirect_to [main_app, @curation_concern] }
+            format.json { render work_to_render, status: :ok, location: polymorphic_path([main_app, @curation_concern]) }
+          end
+        end
+
+        def get_curation_concern
+          work_type = eval(params[:work_type])
+          @curation_concern = work_type.find(params[:work_id]) unless @curation_concern
+          work_to_render = (params[:work_type].downcase.concat('/show'))
+        end
+
+        def count_text
+          @document_list.count.to_s.concat(@document_list.count == 1 ? " Item" : " Items")
+        end
+
+     end
+  end
+end

--- a/app/models/cart_item.rb
+++ b/app/models/cart_item.rb
@@ -1,0 +1,3 @@
+class CartItem < ApplicationRecord
+  belongs_to :media_cart
+end

--- a/app/models/media_cart.rb
+++ b/app/models/media_cart.rb
@@ -1,0 +1,4 @@
+class MediaCart < ApplicationRecord
+  belongs_to :user
+  has_many :cart_items, dependent: :destroy
+ end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,9 @@
 class User < ApplicationRecord
+  has_one :media_cart, dependent: :destroy
+  has_many :cart_items, through: :media_cart
+
+  after_create :create_user_media_cart
+
   # Connects this user object to Hydra behaviors.
   include Hydra::User
   # Connects this user object to Role-management behaviors.
@@ -8,8 +13,6 @@ class User < ApplicationRecord
   # Connects this user object to Hyrax behaviors.
   include Hyrax::User
   include Hyrax::UserUsageStats
-
-
 
   if Blacklight::Utils.needs_attr_accessible?
     attr_accessible :email, :password, :password_confirmation
@@ -32,5 +35,26 @@ class User < ApplicationRecord
   # in order to send emails
   def mailboxer_email(_object)
     email
+  end
+
+  # Create shopping cart for user when they create an account
+  def create_user_media_cart
+    MediaCart.create( { user_id: self.id } )
+  end
+
+  def items_in_cart
+    cart_items.select{ |i| i.downloaded? == false }
+  end
+
+  def work_ids_in_cart
+    items_in_cart.map{ |i| i.work_id }
+  end
+
+  def downloaded_items
+    cart_items.select{ |i| i.downloaded? == true }
+  end
+
+  def downloaded_work_ids
+    downloaded_items.map{ |i| i.work_id }
   end
 end

--- a/app/presenters/morphosource/presenter_methods.rb
+++ b/app/presenters/morphosource/presenter_methods.rb
@@ -31,6 +31,15 @@ module Morphosource
                                  presenter_class: Hyrax::WorkShowPresenter,
                                  presenter_args: presenter_factory_arguments)
     end
-    
+
+    # media cart method
+    def works_in_cart
+      current_ability.current_user.work_ids_in_cart
+    end
+
+    def downloaded_works
+      current_ability.current_user.downloaded_work_ids 
+    end
+
   end
 end

--- a/app/search_builders/morphosource/my/cart_items/cart_items_search_builder.rb
+++ b/app/search_builders/morphosource/my/cart_items/cart_items_search_builder.rb
@@ -1,0 +1,24 @@
+# Search builder for items in current user's media cart (cart items with downloaded = false)
+module Morphosource
+  module My
+    module CartItems
+
+      class CartItemsSearchBuilder < ::SearchBuilder
+        include Hyrax::FilterByType
+
+        self.default_processor_chain += [:show_only_cart_items_owned_by_current_user]
+
+        def only_works?
+          true
+        end
+
+        def show_only_cart_items_owned_by_current_user(solr_parameters)
+          solr_parameters[:fq] ||= []
+          solr_parameters[:fq] += [
+            ActiveFedora::SolrQueryBuilder.construct_query_for_ids(current_user.work_ids_in_cart)
+          ]
+        end
+      end
+    end
+  end
+end

--- a/app/search_builders/morphosource/my/cart_items/downloads_search_builder.rb
+++ b/app/search_builders/morphosource/my/cart_items/downloads_search_builder.rb
@@ -1,0 +1,24 @@
+# Search builder current user's previously downloaded items (cart items with downloaded = true)
+module Morphosource
+  module My
+    module CartItems
+
+      class DownloadsSearchBuilder < ::SearchBuilder
+        include Hyrax::FilterByType
+
+        self.default_processor_chain += [:show_only_cart_items_downloaded_by_current_user]
+
+        def only_works?
+          true
+        end
+
+        def show_only_cart_items_downloaded_by_current_user(solr_parameters)
+          solr_parameters[:fq] ||= []
+          solr_parameters[:fq] += [
+            ActiveFedora::SolrQueryBuilder.construct_query_for_ids(current_user.downloaded_work_ids)
+          ]
+        end
+      end
+    end
+  end
+end

--- a/app/views/_user_util_links.html.erb
+++ b/app/views/_user_util_links.html.erb
@@ -1,0 +1,29 @@
+<ul id="user_utility_links" class="nav navbar-nav navbar-right">
+  <%= render 'shared/locale_picker' if available_translations.size > 1 %>
+  <% if user_signed_in? %>
+    <li>
+      <%= render_notifications(user: current_user) %>
+    </li>
+    <li class="dropdown">
+      <%= link_to hyrax.dashboard_profile_path(current_user), role: 'button', data: { toggle: 'dropdown' }, aria: { haspopup: true, expanded: false, controls: 'user-util-links' } do %>
+        <span class="sr-only"><%= t("hyrax.toolbar.profile.sr_action") %></span>
+        <span class="hidden-xs">&nbsp;<%= current_user.name %></span>
+        <span class="sr-only"> <%= t("hyrax.toolbar.profile.sr_target") %></span>
+        <span class="fa fa-user" aria-hidden="true"></span>
+        <span class="caret"></span>
+      <% end %>
+      <ul id="user-util-links" class="dropdown-menu dropdown-menu-right" role="menu">
+        <li><%= link_to t("hyrax.toolbar.dashboard.menu"), hyrax.dashboard_path %></li>
+
+        <li class="divider"></li>
+        <li><%= link_to t("hyrax.toolbar.profile.logout"), main_app.destroy_user_session_path %></li>
+      </ul>
+    </li><!-- /.btn-group -->
+  <% else %>
+    <li>
+      <%= link_to main_app.new_user_session_path do %>
+        <span class="glyphicon glyphicon-log-in" aria-hidden="true"></span> <%= t("hyrax.toolbar.profile.login") %>
+      <% end %>
+    </li>
+  <% end %>
+</ul>

--- a/app/views/_user_util_links.html.erb
+++ b/app/views/_user_util_links.html.erb
@@ -19,6 +19,12 @@
         <li><%= link_to t("hyrax.toolbar.profile.logout"), main_app.destroy_user_session_path %></li>
       </ul>
     </li><!-- /.btn-group -->
+    <!-- Show shopping cart icon if user signed in -->
+    <li>
+      <%= link_to main_app.my_cart_path do %>
+        <span class="fa fa-shopping-cart" aria-hidden="true"></span>
+      <% end %>
+    </li>
   <% else %>
     <li>
       <%= link_to main_app.new_user_session_path do %>

--- a/app/views/hyrax/base/show.html.erb
+++ b/app/views/hyrax/base/show.html.erb
@@ -5,6 +5,15 @@
 <div class="row work-type">
   <div class="col-xs-12">
     <%= render 'work_type', presenter: @presenter %>
+    <div class="pull-right">
+      <% if signed_in? %>
+        <% if @presenter.works_in_cart.include? params[:id] %>
+          <%= link_to "Item in Cart", main_app.my_cart_path, class: 'btn btn-danger' %>
+        <% else %>
+          <%= link_to "Add to Cart", main_app.add_to_cart_path(:work_id => @presenter.id, :media_cart_id => current_user.media_cart.id, :work_type => @presenter.model_name.name), class: 'btn btn-info', :method => :post %>
+        <% end %>
+      <% end %>   
+    </div>
   </div>
   <div class="col-xs-12">&nbsp;</div>
   <div itemscope itemtype="http://schema.org/CreativeWork" class="col-xs-12">

--- a/app/views/hyrax/dashboard/_sidebar.html.erb
+++ b/app/views/hyrax/dashboard/_sidebar.html.erb
@@ -1,0 +1,21 @@
+<% menu = Hyrax::MenuPresenter.new(self) %>
+<div class="sidebar-toggle"><span class="fa fa-chevron-circle-right"></span></div>
+<nav>
+  <ul class="nav nav-pills nav-stacked">
+    <li>
+      <div class="profile">
+        <div class="profile-image">
+          <%= image_tag current_user.avatar.url(:thumb), width: 100 if current_user.avatar.present? %>
+        </div>
+        <div class="profile-data">
+          <div class="profile-data-name"><%= current_user.name %></div>
+        </div>
+      </div>
+    </li>
+
+    <%= render 'hyrax/dashboard/sidebar/activity', menu: menu %>
+    <%= render 'hyrax/dashboard/sidebar/repository_content', menu: menu %>
+    <%= render 'hyrax/dashboard/sidebar/tasks', menu: menu %>
+    <%= render 'hyrax/dashboard/sidebar/configuration', menu: menu %>
+  </ul>
+</nav>

--- a/app/views/hyrax/dashboard/_sidebar.html.erb
+++ b/app/views/hyrax/dashboard/_sidebar.html.erb
@@ -1,3 +1,4 @@
+<%# Override to include Media Cart %>
 <% menu = Hyrax::MenuPresenter.new(self) %>
 <div class="sidebar-toggle"><span class="fa fa-chevron-circle-right"></span></div>
 <nav>
@@ -14,6 +15,7 @@
     </li>
 
     <%= render 'hyrax/dashboard/sidebar/activity', menu: menu %>
+    <%= render 'hyrax/dashboard/sidebar/downloads', menu: menu %>
     <%= render 'hyrax/dashboard/sidebar/repository_content', menu: menu %>
     <%= render 'hyrax/dashboard/sidebar/tasks', menu: menu %>
     <%= render 'hyrax/dashboard/sidebar/configuration', menu: menu %>

--- a/app/views/hyrax/dashboard/sidebar/_downloads.html.erb
+++ b/app/views/hyrax/dashboard/sidebar/_downloads.html.erb
@@ -1,0 +1,11 @@
+<li class="h5"><%= t('hyrax.admin.sidebar.repository_objects') %></li>
+
+  <%= menu.nav_link(hyrax.my_collections_path,
+                    also_active_for: hyrax.dashboard_collections_path) do %>
+    <span class="fa fa-folder-open" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.collections') %></span>
+  <% end %>
+
+  <%= menu.nav_link(hyrax.my_works_path,
+                    also_active_for: hyrax.dashboard_works_path) do %>
+    <span class="fa fa-file" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.works') %></span>
+  <% end %>

--- a/app/views/hyrax/dashboard/sidebar/_downloads.html.erb
+++ b/app/views/hyrax/dashboard/sidebar/_downloads.html.erb
@@ -1,11 +1,9 @@
-<li class="h5"><%= t('hyrax.admin.sidebar.repository_objects') %></li>
+<li class="h5"><%= t('morphosource.admin.sidebar.downloads') %></li>
 
-  <%= menu.nav_link(hyrax.my_collections_path,
-                    also_active_for: hyrax.dashboard_collections_path) do %>
-    <span class="fa fa-folder-open" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.collections') %></span>
+  <%= menu.nav_link(main_app.my_cart_path) do %>
+    <span class="fa fa-shopping-cart" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('morphosource.admin.sidebar.media_cart') %></span>
   <% end %>
 
-  <%= menu.nav_link(hyrax.my_works_path,
-                    also_active_for: hyrax.dashboard_works_path) do %>
-    <span class="fa fa-file" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.works') %></span>
+  <%= menu.nav_link(main_app.my_downloads_path) do %>
+    <span class="fa fa-download" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('morphosource.admin.sidebar.previous_downloads') %></span>
   <% end %>

--- a/app/views/morphosource/my/_document_list.html.erb
+++ b/app/views/morphosource/my/_document_list.html.erb
@@ -1,0 +1,4 @@
+<% # container for all documents in index view -%>
+<div class="table-responsive" id="documents">
+  <%= render 'default_group', docs: @response.docs %>
+</div>

--- a/app/views/morphosource/my/_document_list.html.erb
+++ b/app/views/morphosource/my/_document_list.html.erb
@@ -1,4 +1,4 @@
-<% # container for all documents in index view -%>
+
 <div class="table-responsive" id="documents">
-  <%= render 'default_group', docs: @response.docs %>
+  <%= render 'morphosource/my/cart_items/default_group', docs: @response.docs, items: @items %>
 </div>

--- a/app/views/morphosource/my/_scripts.js.erb
+++ b/app/views/morphosource/my/_scripts.js.erb
@@ -1,0 +1,3 @@
+// hide or show the batch update buttons on page startup
+window.document_list_count = <%= @document_list.count %>;
+toggleButtons(<%= !@empty_batch %>);

--- a/app/views/morphosource/my/cart_items/_default_group.html.erb
+++ b/app/views/morphosource/my/cart_items/_default_group.html.erb
@@ -1,0 +1,18 @@
+<table class="table table-striped works-list">
+  <caption class="sr-only"><%= t("hyrax.dashboard.my.sr.listing") %> <%= application_name %></caption>
+  <thead>
+  <tr>
+    <th class="check-all"><label for="check_all" class="sr-only"><%= t("hyrax.dashboard.my.sr.check_all_label") %></label><%= render_check_all %></th>
+    <th><%= t("hyrax.dashboard.my.heading.title") %></th>
+    <th><%= t("hyrax.dashboard.my.heading.date_uploaded") %></th>
+    <th><%= t("hyrax.dashboard.my.heading.highlighted") %></th>
+    <th><%= t("hyrax.dashboard.my.heading.visibility") %></th>
+    <th><%= t("hyrax.dashboard.my.heading.action") %></th>
+  </tr>
+  </thead>
+  <tbody>
+  <% docs.each_with_index do |document, counter| %>
+      <%= render 'list_works', document: document, counter: counter, presenter: Hyrax::WorkShowPresenter.new(document, current_ability) %>
+  <% end %>
+  </tbody>
+</table>

--- a/app/views/morphosource/my/cart_items/_default_group.html.erb
+++ b/app/views/morphosource/my/cart_items/_default_group.html.erb
@@ -5,14 +5,15 @@
     <th class="check-all"><label for="check_all" class="sr-only"><%= t("hyrax.dashboard.my.sr.check_all_label") %></label><%= render_check_all %></th>
     <th><%= t("hyrax.dashboard.my.heading.title") %></th>
     <th><%= t("hyrax.dashboard.my.heading.date_uploaded") %></th>
-    <th><%= t("hyrax.dashboard.my.heading.highlighted") %></th>
     <th><%= t("hyrax.dashboard.my.heading.visibility") %></th>
+    <th><%= t("morphosource.dashboard.my.heading.file_visibility") %></th>
     <th><%= t("hyrax.dashboard.my.heading.action") %></th>
   </tr>
   </thead>
   <tbody>
   <% docs.each_with_index do |document, counter| %>
-      <%= render 'list_works', document: document, counter: counter, presenter: Hyrax::WorkShowPresenter.new(document, current_ability) %>
+    <% item = CartItem.where(:work_id => document.id)[0] %>
+    <%= render 'morphosource/my/cart_items/list_works', document: document, counter: counter, item: item, presenter: Hyrax::WorkShowPresenter.new(document, current_ability) %>
   <% end %>
   </tbody>
 </table>

--- a/app/views/morphosource/my/cart_items/_list_works.html.erb
+++ b/app/views/morphosource/my/cart_items/_list_works.html.erb
@@ -1,0 +1,40 @@
+<tr id="document_<%= document.id %>">
+
+  <td>
+    <label for="batch_document_<%= document.id %>" class="sr-only"><%= t("hyrax.dashboard.my.sr.batch_checkbox") %></label>
+    <%= render 'hyrax/batch_select/add_button', document: document %>&nbsp;
+  </td>
+
+  <td>
+    <div class='media'>
+      <%= link_to [main_app, document], class: 'media-left', 'aria-hidden' => true do %>
+        <%= render_thumbnail_tag document, { class: 'hidden-xs file_listing_thumbnail' }, { suppress_link: true } %>
+      <% end %>
+
+      <div class='media-body'>
+        <div class='media-heading'>
+
+          <%= link_to [main_app, document], id: "src_copy_link#{document.id}", class: 'document-title' do %>
+            <span class="sr-only">
+              <%= t("hyrax.dashboard.my.sr.show_label") %>
+            </span>
+            <%= document.title_or_label %>
+          <% end %>
+
+          <br />
+          <%= render_collection_links(document) %>
+
+        </div>
+      </div>
+    </div>
+  </td>
+
+  <td class="date"><%= document.date_uploaded %></td>
+  <td class='text-center'>
+    <span class="fa <%= current_user.trophies.where(work_id: document.id).exists? ? 'fa-star highlighted-work' : 'fa-star-o trophy-off' %>" aria-hidden="true"></span></td>
+  <td><%= render_visibility_link document %></td>
+
+  <td>
+    <%= render 'work_action_menu', document: document %>
+  </td>
+</tr>

--- a/app/views/morphosource/my/cart_items/_list_works.html.erb
+++ b/app/views/morphosource/my/cart_items/_list_works.html.erb
@@ -28,13 +28,21 @@
       </div>
     </div>
   </td>
-
-  <td class="date"><%= document.date_uploaded %></td>
-  <td class='text-center'>
-    <span class="fa <%= current_user.trophies.where(work_id: document.id).exists? ? 'fa-star highlighted-work' : 'fa-star-o trophy-off' %>" aria-hidden="true"></span></td>
-  <td><%= render_visibility_link document %></td>
-
-  <td>
-    <%= render 'work_action_menu', document: document %>
-  </td>
-</tr>
+  <!-- Date Cart Item was created -->
+    <td class="date"><%= item.created_at.strftime("%Y-%m-%d") %></td>
+    <td><%= render_visibility_link document %></td>
+    <td>
+      <div style="display:flex; flex-direction: column; justify-content: space-around; align-items: flex-start;">
+        <% unless document.file_set_visibilities.nil? %>
+          <% document.file_set_visibilities.each do |visibility| %>
+            <%= visibility_badge(visibility) %>
+            <div style="height: 3px;"></div>
+          <% end %>
+        <% end %>
+      </div>
+    </td>
+    <!-- Delete Cart Item -->
+    <td>
+      <%= link_to "Remove", main_app.remove_from_cart_path(item), class: 'btn btn-sm btn-danger delete', :method => :delete %>
+    </td>
+  </tr>

--- a/app/views/morphosource/my/cart_items/_results_pagination.html.erb
+++ b/app/views/morphosource/my/cart_items/_results_pagination.html.erb
@@ -1,0 +1,9 @@
+<% if @response.total_pages > 1 %>
+ <div class="row record-padding">
+  <div class="col-md-9">
+    <div class="pagination">
+      <%= paginate @response, outer_window: 2, theme: 'blacklight', route_set: hyrax %>
+    </div>
+  </div>
+ </div>
+<% end %>

--- a/app/views/morphosource/my/cart_items/_results_pagination.html.erb
+++ b/app/views/morphosource/my/cart_items/_results_pagination.html.erb
@@ -2,7 +2,7 @@
  <div class="row record-padding">
   <div class="col-md-9">
     <div class="pagination">
-      <%= paginate @response, outer_window: 2, theme: 'blacklight', route_set: hyrax %>
+      <%= paginate @response, outer_window: 2, theme: 'blacklight' %>
     </div>
   </div>
  </div>

--- a/app/views/morphosource/my/cart_items/index.html.erb
+++ b/app/views/morphosource/my/cart_items/index.html.erb
@@ -1,77 +1,44 @@
-<% provide :page_title, t("hyrax.admin.sidebar.works") %>
-
-<% provide :head do %>
-  <%= rss_feed_link_tag route_set: hyrax %>
-  <%= atom_feed_link_tag route_set: hyrax %>
+<% if @cart %>
+  <% provide :page_title, t("morphosource.admin.sidebar.media_cart") %>
+<% else %>
+  <% provide :page_title, t("morphosource.admin.sidebar.downloads") %>
 <% end %>
 
-<script>
-//<![CDATA[
-  <%= render partial: 'scripts', formats: [:js] %>
-//]]>
-</script>
-
-<% provide :page_header do %>
-  <h1><span class="fa fa-file" aria-hidden="true"></span> <%= t("hyrax.admin.sidebar.works") %></h1>
-  <% if current_ability.can_create_any_work? %>
-    <div class="pull-right">
-      <% if @create_work_presenter.many? %>
-        <% if Flipflop.batch_upload? %>
-          <%= link_to(
-                t(:'helpers.action.batch.new'),
-                '#',
-                data: { behavior: "select-work", target: "#worktypes-to-create", 'create-type' => 'batch' },
-                class: 'btn btn-primary'
-              ) %>
-        <% end %>
-        <%= link_to(
-              t(:'helpers.action.work.new'),
-              '#',
-              data: { behavior: "select-work", target: "#worktypes-to-create", 'create-type' => 'single' },
-              class: 'btn btn-primary'
-            ) %>
-      <% else # simple link to the first work type %>
-        <% if Flipflop.batch_upload? %>
-          <%= link_to(
-              t(:'helpers.action.batch.new'),
-              hyrax.new_batch_upload_path(payload_concern: @create_work_presenter.first_model),
-              class: 'btn btn-primary'
-              ) %>
-        <% end %>
-        <%= link_to(
-              t(:'helpers.action.work.new'),
-              new_polymorphic_path([main_app, @create_work_presenter.first_model]),
-              class: 'btn btn-primary'
-            ) %>
-      <% end %>
-    </div>
-  <% end %>
-<% end %>
+<nav class="breadcrumb" role="region" aria-label="Breadcrumb">
+  <ol>
+    <li><a href="/?locale=en">Home</a></li>
+    <li><a href="/dashboard?locale=en">Dashboard</a></li>
+    <% if @cart %>
+      <li class="active">Media Cart</li>
+    <% else %>
+      <li class="active">Downloads</li>
+    <% end %>
+  </ol>
+</nav>
 
 <div class="row">
-  <div class="col-md-12">
-    <div class="panel panel-default <%= 'tabs' if current_page?(hyrax.dashboard_works_path(locale: nil)) || @managed_works_count > 0 %>">
-      <%= render 'tabs' if current_page?(hyrax.dashboard_works_path(locale: nil)) || @managed_works_count > 0 %>
-      <div class="panel-heading">
-        <% if current_page?(hyrax.my_works_path(locale: nil)) %>
-          <span class="count-display"><%= I18n.t('hyrax.my.count.works.you_own', total_count: @response.total_count).html_safe %></span>
-        <% elsif current_page?(hyrax.dashboard_works_path(locale: nil)) && !current_ability.admin? %>
-          <span class="count-display"><%= I18n.t('hyrax.my.count.works.you_manage', total_count: @response.total_count).html_safe %></span>
-        <% else %>
-          <span class="count-display"><%= I18n.t('hyrax.my.count.works.in_repo', total_count: @response.total_count).html_safe %></span>
-        <% end %>
-      </div>
-      <div class="panel-body">
-        <%= render 'search_header' %>
-        <h2 class="sr-only">Works listing</h2>
-        <%= render 'document_list' %>
-
-        <%= render 'results_pagination' %>
-      </div>
-    </div>
+  <div class="col-xs-12 main-header">
+    <h1>
+      <% if @cart %>
+        <span class="fa fa-shopping-cart" aria-hidden="true"></span>
+        Media Cart ( <%= @count_text %> )
+      <% else %>
+        <span class="fa fa-download" aria-hidden="true"></span>
+        Downloads ( <%= @count_text %> )
+      <% end %>
+    </h1>
+    <div class="pull-right"></div>
   </div>
 </div>
 
+<script>
+//<![CDATA[
+  <%= render partial: 'morphosource/my/scripts', formats: [:js] %>
+//]]>
+</script>
 
-
-<%= render '/shared/select_work_type_modal', create_work_presenter: @create_work_presenter if @create_work_presenter.many? %>
+<div class="panel-body">
+  <h2 class="sr-only">Works listing</h2>
+  <%= render 'morphosource/my/document_list' %>
+  <%= render 'morphosource/my/cart_items/results_pagination' %>
+</div>

--- a/app/views/morphosource/my/cart_items/index.html.erb
+++ b/app/views/morphosource/my/cart_items/index.html.erb
@@ -1,0 +1,77 @@
+<% provide :page_title, t("hyrax.admin.sidebar.works") %>
+
+<% provide :head do %>
+  <%= rss_feed_link_tag route_set: hyrax %>
+  <%= atom_feed_link_tag route_set: hyrax %>
+<% end %>
+
+<script>
+//<![CDATA[
+  <%= render partial: 'scripts', formats: [:js] %>
+//]]>
+</script>
+
+<% provide :page_header do %>
+  <h1><span class="fa fa-file" aria-hidden="true"></span> <%= t("hyrax.admin.sidebar.works") %></h1>
+  <% if current_ability.can_create_any_work? %>
+    <div class="pull-right">
+      <% if @create_work_presenter.many? %>
+        <% if Flipflop.batch_upload? %>
+          <%= link_to(
+                t(:'helpers.action.batch.new'),
+                '#',
+                data: { behavior: "select-work", target: "#worktypes-to-create", 'create-type' => 'batch' },
+                class: 'btn btn-primary'
+              ) %>
+        <% end %>
+        <%= link_to(
+              t(:'helpers.action.work.new'),
+              '#',
+              data: { behavior: "select-work", target: "#worktypes-to-create", 'create-type' => 'single' },
+              class: 'btn btn-primary'
+            ) %>
+      <% else # simple link to the first work type %>
+        <% if Flipflop.batch_upload? %>
+          <%= link_to(
+              t(:'helpers.action.batch.new'),
+              hyrax.new_batch_upload_path(payload_concern: @create_work_presenter.first_model),
+              class: 'btn btn-primary'
+              ) %>
+        <% end %>
+        <%= link_to(
+              t(:'helpers.action.work.new'),
+              new_polymorphic_path([main_app, @create_work_presenter.first_model]),
+              class: 'btn btn-primary'
+            ) %>
+      <% end %>
+    </div>
+  <% end %>
+<% end %>
+
+<div class="row">
+  <div class="col-md-12">
+    <div class="panel panel-default <%= 'tabs' if current_page?(hyrax.dashboard_works_path(locale: nil)) || @managed_works_count > 0 %>">
+      <%= render 'tabs' if current_page?(hyrax.dashboard_works_path(locale: nil)) || @managed_works_count > 0 %>
+      <div class="panel-heading">
+        <% if current_page?(hyrax.my_works_path(locale: nil)) %>
+          <span class="count-display"><%= I18n.t('hyrax.my.count.works.you_own', total_count: @response.total_count).html_safe %></span>
+        <% elsif current_page?(hyrax.dashboard_works_path(locale: nil)) && !current_ability.admin? %>
+          <span class="count-display"><%= I18n.t('hyrax.my.count.works.you_manage', total_count: @response.total_count).html_safe %></span>
+        <% else %>
+          <span class="count-display"><%= I18n.t('hyrax.my.count.works.in_repo', total_count: @response.total_count).html_safe %></span>
+        <% end %>
+      </div>
+      <div class="panel-body">
+        <%= render 'search_header' %>
+        <h2 class="sr-only">Works listing</h2>
+        <%= render 'document_list' %>
+
+        <%= render 'results_pagination' %>
+      </div>
+    </div>
+  </div>
+</div>
+
+
+
+<%= render '/shared/select_work_type_modal', create_work_presenter: @create_work_presenter if @create_work_presenter.many? %>

--- a/config/locales/morphosource.en.yml
+++ b/config/locales/morphosource.en.yml
@@ -1,5 +1,10 @@
 en:
   morphosource:
+    admin:
+      sidebar:
+        downloads: 'Downloads'
+        media_cart: 'Media Cart'
+        previous_downloads: 'Previous Downloads'
     base:
       form_progress:
         required_format: 'File formats match selected media type'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,4 +47,13 @@ Rails.application.routes.draw do
     end
   end
 
+  scope module: :morphosource do
+    scope module: :my do
+      get 'dashboard/my/downloads', action: :index, controller: :cart_items, as: 'my_downloads'
+      get 'dashboard/my/cart', action: :index, controller: :cart_items, as: 'my_cart'
+      post 'add_to_cart', action: :create, controller: :cart_items
+      delete '/cart_items/:id', to: 'cart_items#destroy', as: 'remove_from_cart'
+    end
+  end
+
 end

--- a/db/migrate/20190211161448_create_media_carts.rb
+++ b/db/migrate/20190211161448_create_media_carts.rb
@@ -1,0 +1,9 @@
+class CreateMediaCarts < ActiveRecord::Migration[5.1]
+  def change
+    create_table :media_carts do |t|
+      t.integer :user_id, null: false
+      t.index :user_id
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190211161505_create_cart_items.rb
+++ b/db/migrate/20190211161505_create_cart_items.rb
@@ -1,0 +1,12 @@
+class CreateCartItems < ActiveRecord::Migration[5.1]
+  def change
+    create_table :cart_items do |t|
+      t.integer :media_cart_id, null: false
+      t.string :work_id, null: false
+      t.boolean :downloaded, default: false
+      t.index :media_cart_id
+      t.index :work_id
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181128205925) do
+ActiveRecord::Schema.define(version: 20190211161505) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -25,6 +25,16 @@ ActiveRecord::Schema.define(version: 20181128205925) do
     t.datetime "updated_at", null: false
     t.index ["document_id"], name: "index_bookmarks_on_document_id"
     t.index ["user_id"], name: "index_bookmarks_on_user_id"
+  end
+
+  create_table "cart_items", force: :cascade do |t|
+    t.integer "media_cart_id", null: false
+    t.string "work_id", null: false
+    t.boolean "downloaded", default: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["media_cart_id"], name: "index_cart_items_on_media_cart_id"
+    t.index ["work_id"], name: "index_cart_items_on_work_id"
   end
 
   create_table "checksum_audit_logs", force: :cascade do |t|
@@ -89,6 +99,11 @@ ActiveRecord::Schema.define(version: 20181128205925) do
     t.index ["parent_id"], name: "index_curation_concerns_operations_on_parent_id"
     t.index ["rgt"], name: "index_curation_concerns_operations_on_rgt"
     t.index ["user_id"], name: "index_curation_concerns_operations_on_user_id"
+  end
+
+  create_table "events", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "featured_works", force: :cascade do |t|
@@ -214,6 +229,13 @@ ActiveRecord::Schema.define(version: 20181128205925) do
     t.index ["receiver_id", "receiver_type"], name: "index_mailboxer_receipts_on_receiver_id_and_receiver_type"
   end
 
+  create_table "media_carts", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_media_carts_on_user_id"
+  end
+
   create_table "minter_states", force: :cascade do |t|
     t.string "namespace", default: "default", null: false
     t.string "template", null: false
@@ -244,6 +266,26 @@ ActiveRecord::Schema.define(version: 20181128205925) do
     t.date "release_date"
     t.string "release_period"
     t.index ["source_id"], name: "index_permission_templates_on_source_id", unique: true
+  end
+
+  create_table "physical_objects", force: :cascade do |t|
+    t.text "description"
+    t.text "current_location"
+    t.text "original_location"
+    t.date "date_created"
+    t.string "identifier"
+    t.text "url"
+    t.text "bibliographic_citation"
+    t.string "publisher"
+    t.boolean "vouchered", default: false, null: false
+    t.string "institution"
+    t.string "numeric_time"
+    t.string "periodic_time"
+    t.string "catalog_number"
+    t.string "collection_code"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["institution"], name: "index_physical_objects_on_institution"
   end
 
   create_table "proxy_deposit_requests", force: :cascade do |t|
@@ -546,6 +588,7 @@ ActiveRecord::Schema.define(version: 20181128205925) do
     t.binary "zotero_token"
     t.string "zotero_userid"
     t.string "preferred_locale"
+    t.integer "media_cart_id"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/spec/controllers/morphosource/my/cart_items_controller_spec.rb
+++ b/spec/controllers/morphosource/my/cart_items_controller_spec.rb
@@ -1,0 +1,105 @@
+# Generated via
+#  `rails generate hyrax:work Media`
+require 'rails_helper'
+require 'iiif_manifest'
+include ActionDispatch::TestProcess
+
+RSpec.describe Morphosource::My::CartItemsController, :type => :controller  do
+
+  # Work already added to cart
+  let(:work)          { Media.create(id: "aaa", title: ["Test Media Work"])}
+  # Work not yet added to cart
+  let(:work2)         { Media.create(id: "fff", title: ["Test Media Work"])}
+
+  let(:current_user)  { User.create(id: 1, email: "example@email.com", password: "password") }
+  let(:media_cart)    { MediaCart.where(user_id: current_user.id)[0] }
+  let(:cartItem1)     { CartItem.create( media_cart_id: media_cart.id, work_id: "aaa") }
+  let(:cartItem2)     { CartItem.create( media_cart_id: media_cart.id, work_id: "bbb") }
+  let(:cartItem3)     { CartItem.create( media_cart_id: media_cart.id, work_id: "ccc") }
+  let(:cartItem4)     { CartItem.create( media_cart_id: media_cart.id, work_id: "ddd", downloaded: true) }
+  let(:cartItem5)     { CartItem.create( media_cart_id: media_cart.id, work_id: "eee", downloaded: true) }
+
+  let(:allCartItems)  { [cartItem1, cartItem2, cartItem3, cartItem4, cartItem5] }
+
+  before do
+    allCartItems.each{ |i| i.touch }
+    sign_in current_user
+  end
+
+  describe "#search_builder_class" do
+
+    context "user views the media cart" do
+      before do
+        allow(subject).to receive_message_chain(:request, :original_fullpath).and_return('/dashboard/my/cart')
+      end
+
+      it 'returns the CartItems Search Builder' do
+        expect(subject.search_builder_class).to eq (Morphosource::My::CartItems::CartItemsSearchBuilder)
+      end
+    end
+
+    context "user views their previous downloads" do
+      before do
+        allow(subject).to receive_message_chain(:request, :original_fullpath).and_return('/dashboard/my/downloads')
+      end
+
+      it 'returns the Downloads Search Builder' do
+        expect(subject.search_builder_class).to eq (Morphosource::My::CartItems::DownloadsSearchBuilder)
+      end
+    end
+  end
+
+  describe "#works_in_cart" do
+
+    it "returns only cart items that have not yet been downloaded" do
+      expect(subject.send(:works_in_cart)).to match_array(["aaa","bbb","ccc"])
+    end
+  end
+
+  describe "#create" do
+
+    context 'item is not in cart' do
+      let(:post_params) { {:media_cart_id => media_cart.id, :work_id => work2.id, :work_type => "Media"} }
+
+      it "creates a new CartItem" do
+        expect{
+          process :create, method: :post, params: post_params
+          }.to change{CartItem.count}.by(1)
+      end
+
+      it "returns flash message 'Item Added to Cart'" do
+        post :create, params: post_params
+        expect(response.flash[:notice]).to eq('Item Added to Cart')
+      end
+    end
+
+    context "item is already in the user's cart" do
+      let(:post_params) { {:media_cart_id => media_cart.id, :work_id => work.id, :work_type => "Media"} }
+
+      it "creates a new CartItem" do
+        expect{
+          process :create, method: :post, params: post_params
+        }.to change{CartItem.count}.by(0)
+      end
+
+      it "returns flash message 'Item Already in Cart'" do
+        post :create, params: post_params
+        expect(response.flash[:alert]).to eq('Item Already in Cart')
+      end
+    end
+
+    describe "#destroy" do
+
+      it "deletes the cart item" do
+        expect{
+          process :destroy, method: :delete, params: {:id => cartItem1.id}
+        }.to change{CartItem.count}.by(-1)
+      end
+
+      it "returns flash message 'Item Removed from Cart'" do
+        delete :destroy, params: {:id => cartItem1.id}
+        expect(response.flash[:notice]).to eq('Item Removed from Cart')
+      end
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+
+  let(:user)  { User.create(id: 1, email: "example@email.com", password: "password") }
+  let(:media_cart)    { MediaCart.where(user_id: user.id)[0] }
+  let(:cartItem1)     { CartItem.create(id: 1, media_cart_id: media_cart.id, work_id: "aaa") }
+  let(:cartItem2)     { CartItem.create(id: 2, media_cart_id: media_cart.id, work_id: "bbb") }
+  let(:cartItem3)     { CartItem.create(id: 3, media_cart_id: media_cart.id, work_id: "ccc") }
+  let(:cartItem4)     { CartItem.create(id: 4, media_cart_id: media_cart.id, work_id: "ddd", downloaded: true) }
+  let(:cartItem5)     { CartItem.create(id: 5, media_cart_id: media_cart.id, work_id: "eee", downloaded: true) }
+
+  let(:allCartItems)  { [cartItem1, cartItem2, cartItem3, cartItem4, cartItem5] }
+
+  before do
+    # Makes user aware of its cart_items
+    allCartItems.each{ |i| i.touch }
+  end
+
+  describe '#create_user_media_cart' do
+
+    it 'creates a media cart for every new user' do
+      user2 = User.create({email: 'email@example.com', password: "password"})
+      expect(user2.media_cart.present?).to be(true)
+    end
+  end
+
+  describe '#items_in_cart' do
+    it "returns all cart items in the user's shopping cart" do
+      expect(user.items_in_cart).to match_array([cartItem1, cartItem2, cartItem3])
+    end
+  end
+
+  describe '#work_ids_in_cart' do
+    it "returns the work ids of items in the user's shopping cart" do
+      expect(user.work_ids_in_cart).to match_array([cartItem1.work_id, cartItem2.work_id, cartItem3.work_id])
+    end
+  end
+
+  describe '#downloaded_items' do
+    it "returns items the user has downloaded" do
+      expect(user.downloaded_items).to match_array([cartItem4, cartItem5])
+    end
+  end
+
+  describe '#downloaded_work_ids' do
+    it "returns the work ids for items the user has downloaded" do
+      expect(user.downloaded_work_ids).to match_array([cartItem4.work_id, cartItem5.work_id])
+    end
+  end
+end


### PR DESCRIPTION
**To add a media cart to all current users on your machine, run 'User.all.each{|u| u.create_user_media_cart}' in the console.**

- Automatically creates a media cart object for each new user.
- Adds a 'Downloads' section to the dashboard which includes the media cart and previous downloads. 
- Adds a media cart icon to the top right corner for signed-in users.
- Adds a 'Add to Cart' button to work show view for signed-in users.
- 'Add to Cart' button changes to 'Already in Cart' and links to the media cart if the work has already been added to the cart.
- The media cart displays the works that have been added to the cart.
- The previous downloads section displays works that the user has downloaded (not yet implemented, but can try it out by changing a cartItem downloaded property to false)
- Both pages have a count of the number of items on the page
- Users can remove works from the cart by clicking on the 'remove' button
- Flash messages notify users when an item has been successfully added or removed from their cart.