### PR TITLE
MR-418: fix item count and pagination links for media cart and downloads

### DIFF
--- a/app/views/morphosource/my/cart_items/index.html.erb
+++ b/app/views/morphosource/my/cart_items/index.html.erb
@@ -21,10 +21,10 @@
     <h1>
       <% if @cart %>
         <span class="fa fa-shopping-cart" aria-hidden="true"></span>
-        Media Cart ( <%= @count_text %> )
+        Media Cart ( <%= @item_count %> )
       <% else %>
         <span class="fa fa-download" aria-hidden="true"></span>
-        Downloads ( <%= @count_text %> )
+        Downloads ( <%= @item_count %> )
       <% end %>
     </h1>
     <div class="pull-right"></div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -57,11 +57,11 @@ Rails.application.routes.draw do
   get '/submissions/stage_media', to: redirect('/submissions/new')
   get '/submissions/stage_processing_event', to: redirect('/submissions/new')
   get '/submissions/stage_cho', to: redirect('/submissions/new')
-  
+
   scope module: :morphosource do
     scope module: :my do
-      get 'dashboard/my/downloads', action: :index, controller: :cart_items, as: 'my_downloads'
-      get 'dashboard/my/cart', action: :index, controller: :cart_items, as: 'my_cart'
+      get 'dashboard/my/downloads', action: :previous_downloads, controller: :cart_items, as: 'my_downloads'
+      get 'dashboard/my/cart', action: :media_cart, controller: :cart_items, as: 'my_cart'
       post 'add_to_cart', action: :create, controller: :cart_items
       delete '/cart_items/:id', to: 'cart_items#destroy', as: 'remove_from_cart'
     end

--- a/spec/controllers/morphosource/my/cart_items_controller_spec.rb
+++ b/spec/controllers/morphosource/my/cart_items_controller_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Morphosource::My::CartItemsController, :type => :controller  do
 
     context "user views the media cart" do
       before do
-        allow(subject).to receive_message_chain(:request, :original_fullpath).and_return('/dashboard/my/cart')
+        get :media_cart
       end
 
       it 'returns the CartItems Search Builder' do
@@ -40,7 +40,7 @@ RSpec.describe Morphosource::My::CartItemsController, :type => :controller  do
 
     context "user views their previous downloads" do
       before do
-        allow(subject).to receive_message_chain(:request, :original_fullpath).and_return('/dashboard/my/downloads')
+        get :previous_downloads
       end
 
       it 'returns the Downloads Search Builder' do


### PR DESCRIPTION
I discovered a couple of bugs when there are more than 10 items added to the media cart or downloads pages. The page links at the bottom of the media cart page were linking to the downloads page, and the item counts were only counting items on the page instead of total items. This PR resolves both issues.