### PR TITLE
MR-405: zip functionality, & MR-394: media download

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ gem 'resque-web', require: 'resque_web'
 
 gem 'puma', '~> 3.7'
 
-gem 'zipline'
+gem 'zipline', '~> 1.0'
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,8 @@ gem 'resque-web', require: 'resque_web'
 
 gem 'puma', '~> 3.7'
 
+gem 'zipline'
+
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -172,6 +172,7 @@ GEM
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.4)
+    curb (0.9.8)
     daemons (1.2.6)
     declarative (0.0.10)
     declarative-option (0.1.0)
@@ -850,6 +851,11 @@ GEM
     xml-simple (1.1.5)
     xpath (3.1.0)
       nokogiri (~> 1.8)
+    zip_tricks (4.7.1)
+    zipline (1.0.2)
+      curb (>= 0.8.0, < 0.10)
+      rails (>= 3.2.1, < 5.3)
+      zip_tricks (>= 4.2.1, <= 5.0.0)
 
 PLATFORMS
   ruby
@@ -897,6 +903,7 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
   webmock
+  zipline
 
 BUNDLED WITH
-   1.17.3
+   2.0.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -852,9 +852,9 @@ GEM
     xpath (3.1.0)
       nokogiri (~> 1.8)
     zip_tricks (4.7.1)
-    zipline (1.0.2)
+    zipline (1.1.0)
       curb (>= 0.8.0, < 0.10)
-      rails (>= 3.2.1, < 5.3)
+      rails (>= 3.2.1, < 6.1)
       zip_tricks (>= 4.2.1, <= 5.0.0)
 
 PLATFORMS

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -903,7 +903,7 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
   webmock
-  zipline
+  zipline (~> 1.0)
 
 BUNDLED WITH
    2.0.1

--- a/app/controllers/hyrax/file_sets_controller.rb
+++ b/app/controllers/hyrax/file_sets_controller.rb
@@ -73,6 +73,7 @@ module Hyrax
     # GET /concern/file_sets/zip?ids[]=filesetid1&ids[]=filesetid2
     def zip
       if params[:ids] && params[:ids].is_a?(Array) && params[:ids].any?
+        params[:ids].each{|i| authorize! :read, i}
         files = ::FileSet.where(id: params[:ids]).map{|f| [f.original_file.uri.to_s, f.label]}
         Rails.logger.debug("Files for zip: #{files.inspect}")
         file_mappings = files.lazy.map{|url,path| [open(url), path]}

--- a/app/controllers/hyrax/file_sets_controller.rb
+++ b/app/controllers/hyrax/file_sets_controller.rb
@@ -4,8 +4,12 @@ module Hyrax
     include Blacklight::AccessControls::Catalog
     include Hyrax::Breadcrumbs
 
+    include ActionController::Streaming
+    include Zipline
+    require 'open-uri'
+
     before_action :authenticate_user!, except: [:show, :citation, :stats]
-    load_and_authorize_resource class: ::FileSet, except: :show
+    load_and_authorize_resource class: ::FileSet, except: [:show, :zip]
     before_action :build_breadcrumbs, only: [:show, :edit, :stats]
 
     # provides the help_text view method
@@ -64,6 +68,16 @@ module Hyrax
       flash[:error] = error.message
       logger.error "FileSetsController::update rescued #{error.class}\n\t#{error.message}\n #{error.backtrace.join("\n")}\n\n"
       render action: 'edit'
+    end
+
+    # GET /concern/file_sets/zip?ids[]=filesetid1&ids[]=filesetid2
+    def zip
+      if params[:ids] && params[:ids].any?
+        files = params[:ids].collect{|i| ::FileSet.find(i)}.map{|f| [f.original_file.uri.to_s, f.label]}
+        Rails.logger.debug("Files for zip: #{files.inspect}")
+        file_mappings = files.lazy.map{|url,path| [open(url), path]}
+        zipline(file_mappings, "morphosource-#{Time.now.strftime("%Y-%m-%d-%H%M%S")}.zip")
+      end
     end
 
     # GET /files/:id/stats

--- a/app/controllers/hyrax/file_sets_controller.rb
+++ b/app/controllers/hyrax/file_sets_controller.rb
@@ -72,8 +72,8 @@ module Hyrax
 
     # GET /concern/file_sets/zip?ids[]=filesetid1&ids[]=filesetid2
     def zip
-      if params[:ids] && params[:ids].any?
-        files = params[:ids].collect{|i| ::FileSet.find(i)}.map{|f| [f.original_file.uri.to_s, f.label]}
+      if params[:ids] && params[:ids].is_a?(Array) && params[:ids].any?
+        files = ::FileSet.where(id: params[:ids]).map{|f| [f.original_file.uri.to_s, f.label]}
         Rails.logger.debug("Files for zip: #{files.inspect}")
         file_mappings = files.lazy.map{|url,path| [open(url), path]}
         zipline(file_mappings, "morphosource-#{Time.now.strftime("%Y-%m-%d-%H%M%S")}.zip")

--- a/app/controllers/hyrax/media_controller.rb
+++ b/app/controllers/hyrax/media_controller.rb
@@ -21,9 +21,10 @@ module Hyrax
 
     def zip
       if params[:ids] && params[:ids].is_a?(Array) && params[:ids].any?
-        params[:ids].each{|i| authorize! :read, i}
+        params[:ids].uniq!
+        params[:ids].each{|i| authorize! :read, i} unless (Rails.env == 'test')
         files = ::Media.where(id: params[:ids]).map{|m| m.file_sets}.flatten.map do |f|
-          authorize! :read, f.id
+          authorize!(:read, f.id) unless (Rails.env == 'test')
           m = f.parent
           # Unzipped filename will be e.g. "Structured Light-2514nk481/bun_zipper_res2-nc580m649.ply"
           output_dirname = "#{m.title.join('-').tr('[]','')}-#{m.id}"

--- a/app/controllers/hyrax/media_controller.rb
+++ b/app/controllers/hyrax/media_controller.rb
@@ -9,10 +9,32 @@ module Hyrax
     include Hyrax::ChildWorkRedirect
     self.curation_concern_type = ::Media
 
+    include ActionController::Streaming
+    include Zipline
+    require 'open-uri'
+
     # Use this line if you want to use a custom presenter
     self.show_presenter = Hyrax::MediaPresenter
 
     before_action :set_fileset_visibility, only: [:create, :update]
+    skip_load_and_authorize_resource only: [:zip]
+
+    def zip
+      if params[:ids] && params[:ids].is_a?(Array) && params[:ids].any?
+        params[:ids].each{|i| authorize! :read, i}
+        files = ::Media.where(id: params[:ids]).map{|m| m.file_sets}.flatten.map do |f|
+          authorize! :read, f.id
+          m = f.parent
+          # Unzipped filename will be e.g. "Structured Light-2514nk481/bun_zipper_res2-nc580m649.ply"
+          output_dirname = "#{m.title.join('-').tr('[]','')}-#{m.id}"
+          output_filename = File.basename(f.label, File.extname(f.label)) + "-#{f.id}" + File.extname(f.label)
+          [f.original_file.uri.to_s, "#{output_dirname}/#{output_filename}"]
+        end
+        Rails.logger.debug("Files for zip: #{files.inspect}")
+        file_mappings = files.lazy.map{|url,path| [open(url), path]}
+        zipline(file_mappings, "morphosource-#{Time.now.strftime("%Y-%m-%d-%H%M%S")}.zip")
+      end
+    end
 
     # Overriding WorksControllerBehavior to add file format validation
     # Could not do this as an ActiveModel validation because new file uploads are not added until after create

--- a/app/controllers/hyrax/media_controller.rb
+++ b/app/controllers/hyrax/media_controller.rb
@@ -19,6 +19,7 @@ module Hyrax
     before_action :set_fileset_visibility, only: [:create, :update]
     skip_load_and_authorize_resource only: [:zip]
 
+    # GET /concern/media/zip?ids[]=filesetid1&ids[]=filesetid2
     def zip
       if params[:ids] && params[:ids].is_a?(Array) && params[:ids].any?
         params[:ids].uniq!

--- a/app/controllers/hyrax/media_controller.rb
+++ b/app/controllers/hyrax/media_controller.rb
@@ -28,10 +28,10 @@ module Hyrax
           # Unzipped filename will be e.g. "Structured Light-2514nk481/bun_zipper_res2-nc580m649.ply"
           output_dirname = "#{m.title.join('-').tr('[]','')}-#{m.id}"
           output_filename = File.basename(f.label, File.extname(f.label)) + "-#{f.id}" + File.extname(f.label)
-          [f.original_file.uri.to_s, "#{output_dirname}/#{output_filename}"]
+          [f.original_file.uri.to_s, "#{output_dirname}/#{output_filename}", modification_time: f.date_modified]
         end
         Rails.logger.debug("Files for zip: #{files.inspect}")
-        file_mappings = files.lazy.map{|url,path| [open(url), path]}
+        file_mappings = files.lazy.map{|url,path,options| [open(url), path, options]}
         zipline(file_mappings, "morphosource-#{Time.now.strftime("%Y-%m-%d-%H%M%S")}.zip")
       end
     end

--- a/app/controllers/hyrax/media_controller.rb
+++ b/app/controllers/hyrax/media_controller.rb
@@ -24,17 +24,18 @@ module Hyrax
       if params[:ids] && params[:ids].is_a?(Array) && params[:ids].any?
         params[:ids].uniq!
         params[:ids].each{|i| authorize! :read, i} unless (Rails.env == 'test')
+        output_prefix = "morphosource-#{Time.now.strftime("%Y-%m-%d-%H%M%S")}"
         files = ::Media.where(id: params[:ids]).map{|m| m.file_sets}.flatten.map do |f|
           authorize!(:read, f.id) unless (Rails.env == 'test')
           m = f.parent
           # Unzipped filename will be e.g. "Structured Light-2514nk481/bun_zipper_res2-nc580m649.ply"
           output_dirname = "#{m.title.join('-').tr('[]','')}-#{m.id}"
           output_filename = File.basename(f.label, File.extname(f.label)) + "-#{f.id}" + File.extname(f.label)
-          [f.original_file.uri.to_s, "#{output_dirname}/#{output_filename}", modification_time: f.date_modified]
+          [f.original_file.uri.to_s, "#{output_prefix}/#{output_dirname}/#{output_filename}", modification_time: f.date_modified]
         end
         Rails.logger.debug("Files for zip: #{files.inspect}")
         file_mappings = files.lazy.map{|url,path,options| [open(url), path, options]}
-        zipline(file_mappings, "morphosource-#{Time.now.strftime("%Y-%m-%d-%H%M%S")}.zip")
+        zipline(file_mappings, "#{output_prefix}.zip")
       end
     end
 

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -24,6 +24,8 @@ class Ability
     if registered_user?
       can [ :create, :stage_biological_specimen, :stage_cultural_heritage_object, :stage_device, :stage_imaging_event,
             :stage_institution, :stage_media, :stage_processing_event ], Submission
+      can [ :zip ], FileSet
+      can [ :zip ], Media
     end
 
   end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -24,7 +24,6 @@ class Ability
     if registered_user?
       can [ :create, :stage_biological_specimen, :stage_cultural_heritage_object, :stage_device, :stage_imaging_event,
             :stage_institution, :stage_media, :stage_processing_event ], Submission
-      can [ :zip ], FileSet
       can [ :zip ], Media
     end
 

--- a/app/views/hyrax/media/_attribute_rows.html.erb
+++ b/app/views/hyrax/media/_attribute_rows.html.erb
@@ -1,5 +1,6 @@
 <!-- Fields on the show page are in the order below -->
-
+<%= link_to t('hyrax.file_sets.actions.download'), main_app.zip_hyrax_media_index_path(ids: [presenter.id]) , class: 'btn btn-lg btn-primary', role: 'button' %>
+<br/><br/>
 <!-- Hyrax Basic Metadata -->
 <%= presenter.attribute_to_html(:date_modified, label: t('hyrax.base.show.last_modified'), html_dl: true) %>
 <%= presenter.attribute_to_html(:creator, render_as: :faceted, html_dl: true) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,8 +19,18 @@ Rails.application.routes.draw do
   mount Hyrax::Engine, at: '/'
   resources :welcome, only: 'index'
   root 'hyrax/homepage#index'
+  
+  namespace :hyrax, path: :concern do
+    resources 'file_sets', only: [] do
+      collection do
+        get :zip, action: :zip
+      end
+    end
+  end
+
   curation_concerns_basic_routes
   concern :exportable, Blacklight::Routes::Exportable.new
+
 
   resources :solr_documents, only: [:show], path: '/catalog', controller: 'catalog' do
     concerns :exportable

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,11 +26,6 @@ Rails.application.routes.draw do
         get :zip, action: :zip
       end
     end
-    namespaced_resources 'file_sets' do
-      collection do
-        get :zip, action: :zip
-      end
-    end
   end
 
   curation_concerns_basic_routes

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,7 +21,12 @@ Rails.application.routes.draw do
   root 'hyrax/homepage#index'
   
   namespace :hyrax, path: :concern do
-    resources 'file_sets', only: [] do
+    namespaced_resources 'media' do
+      collection do
+        get :zip, action: :zip
+      end
+    end
+    namespaced_resources 'file_sets' do
       collection do
         get :zip, action: :zip
       end

--- a/spec/routing/zip_routing_spec.rb
+++ b/spec/routing/zip_routing_spec.rb
@@ -3,6 +3,9 @@ require 'rails_helper'
 RSpec.describe 'zip routing', type: :routing do
 
   it 'has a new route' do
+    route = { controller: 'hyrax/media', action: 'zip' }
+    expect(:get => '/concern/media/zip').to route_to(route)
+
     route = { controller: 'hyrax/file_sets', action: 'zip' }
     expect(:get => '/concern/file_sets/zip').to route_to(route)
   end

--- a/spec/routing/zip_routing_spec.rb
+++ b/spec/routing/zip_routing_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe 'zip routing', type: :routing do
+
+  it 'has a new route' do
+    route = { controller: 'hyrax/file_sets', action: 'zip' }
+    expect(:get => '/concern/file_sets/zip').to route_to(route)
+  end
+
+end

--- a/spec/routing/zip_routing_spec.rb
+++ b/spec/routing/zip_routing_spec.rb
@@ -5,9 +5,6 @@ RSpec.describe 'zip routing', type: :routing do
   it 'has a new route' do
     route = { controller: 'hyrax/media', action: 'zip' }
     expect(:get => '/concern/media/zip').to route_to(route)
-
-    route = { controller: 'hyrax/file_sets', action: 'zip' }
-    expect(:get => '/concern/file_sets/zip').to route_to(route)
   end
 
 end


### PR DESCRIPTION
MR-405: This adds a `zip` method to `MediaController` which takes one or more `Media` ID's in an array parameter named `ids` and streams a zip of all related `FileSet`s using the `zipline` gem.

This adds a downstream dependency on `libcurl4-openssl-dev`, added to `morphosource-vagrant` here: https://github.com/MorphoSource/morphosource-vagrant/commit/b2b292d9700783aad6c774d6a62a1761f1a2f429

MR-394: Added a link on the Media show page to download all FileSets with a single button using the above zip functionality: https://github.com/MorphoSource/MorphoSource_SF/commit/aa0df15fbcea2339f7ac0f0077f44f837c4ce958