### PR TITLE
MR-393: disable FileSet downloads

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -1,7 +1,7 @@
 class Ability
   include Hydra::Ability
 
-  include Hyrax::Ability
+  include Morphosource::Ability
   self.ability_logic += [:everyone_can_create_curation_concerns]
 
   # Define any customized permissions here.

--- a/app/models/concerns/morphosource/ability.rb
+++ b/app/models/concerns/morphosource/ability.rb
@@ -1,0 +1,19 @@
+module Morphosource
+  module Ability
+    extend ActiveSupport::Concern
+    included do
+      include Hyrax::Ability
+    end
+
+    def download_groups(id)
+      Rails.logger.info('Morphosource::Ability.download_groups called')
+      return []
+    end
+    def download_users(id)
+      Rails.logger.info('Morphosource::Ability.download_users called')
+      return []
+    end
+  end
+end
+    
+Hyrax::Ability.prepend Morphosource::Ability

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -212,7 +212,7 @@ Hyrax.config do |config|
   # config.working_path = Rails.root.join( 'tmp', 'uploads')
 
   # Should the media display partial render a download link?
-  # config.display_media_download_link = true
+  config.display_media_download_link = false
 
   # A configuration point for changing the behavior of the license service
   #   @see Hyrax::LicenseService for implementation details


### PR DESCRIPTION
A better way to do this would probably be if we could just set `cannot [ :download: ], FileSet`, but it seems like Hyrax/CanCanCan uses special logic for determining download permissions. By overriding the `download_users`/`download_groups` methods to always return an empty set, we can completely disable FileSet downloads.