### PR TITLE
MR-133, MR-406 - Download Zipped Files from the Media Cart

### DIFF
--- a/app/controllers/morphosource/my/cart_items_controller.rb
+++ b/app/controllers/morphosource/my/cart_items_controller.rb
@@ -7,16 +7,9 @@ module Morphosource
 
       before_action :get_curation_concern, only: [:create]
 
-      def search_builder_class
-        if @cart
-          Morphosource::My::CartItems::CartItemsSearchBuilder
-        else
-          Morphosource::My::CartItems::DownloadsSearchBuilder
-        end
-      end
-
+      # Used by Add to Cart button on Work show page
       def create
-        unless item_already_in_cart?(params[:work_id])
+        unless work_already_in_cart?(params[:work_id])
           @item = CartItem.new({:media_cart_id => params[:media_cart_id], :work_id => params[:work_id]})
           if @item.save!
             flash[:notice] = 'Item Added to Cart'
@@ -29,42 +22,131 @@ module Morphosource
         after_create_response(@curation_concern)
       end
 
+      # Used when batch-copying previously downloaded items to cart
+      def batch_create
+        ids = params[:batch_document_ids]
+        work_ids = ids.map{|id| CartItem.find(id).work_id}
+        duplicate_work_ids = get_duplicate_works(work_ids, work_ids.uniq)
+        count = ids.count - duplicate_work_ids.count
+        duplicates = duplicate_work_ids.each_with_object([]) do |id, duplicates|
+          duplicates << Media.find(id).title[0]
+        end
+        work_ids.uniq.each do |id|
+          if work_already_in_cart?(id)
+            duplicates << Media.find(id).title[0]
+            count -= 1
+          else
+            @item = CartItem.new({:media_cart_id => current_user.media_cart.id, :work_id => id})
+            @item.save!
+          end
+        end
+        flash[:notice] = "#{count_text(count)} Added to Cart#{duplicates_text(duplicates)}"
+        redirect_to main_app.my_cart_path
+      end
+
+      # Displays items in cart or previous downloads
       def index
-        count_text(@items)
+        @item_count = item_count
+        @items = items
+        @solr_docs = solr_docs
         super
         render 'index'
       end
 
       def media_cart
         @cart = true
-        @items = current_user.items_in_cart
         self.index
       end
 
       def previous_downloads
         @cart = false
-        @items = current_user.downloaded_items
         self.index
       end
 
-      def destroy
-        @item = CartItem.find(params[:id])
-        if @item.destroy
-          flash[:notice] = 'Item Removed from Cart'
+      def download
+        if params[:batch_document_ids]
+          item_ids = params[:batch_document_ids]
         else
-          flash[:alert] = 'Item Remove Unsuccessful'
+          item_ids = current_user.item_ids_in_cart
+        end
+        items = item_ids.map{|id| CartItem.find(id)}
+        work_ids = items.map{|item| item.work_id}
+        mark_as_downloaded(items)
+        redirect_to main_app.zip_hyrax_media_index_path(ids: work_ids)
+      end
+
+      # Used when batch removing items from the media cart
+      # For selecting multiple items, uses batch_document_ids param
+      # Clear Cart button uses current_user's items in cart
+      def batch_destroy
+        if params[:batch_document_ids]
+          all_items = params[:batch_document_ids].map{|id| CartItem.find(id)}
+        else
+          all_items = items_in_cart
+        end
+        count = all_items.count
+        downloaded_items = all_items.select{|item| item.date_downloaded.present?}
+        items = all_items - downloaded_items
+        if items.each(&:destroy)
+          flash[:notice] = "#{count_text(count)} Removed from Cart"
+          downloaded_items.each do |item|
+            item.in_cart = false
+            item.save!
+          end
+        else
+          flash[:alert] = 'Not Able to Remove Items'
         end
         redirect_to main_app.my_cart_path
       end
 
-       private
+      private
 
         def works_in_cart
           current_user.work_ids_in_cart
         end
 
-        def item_already_in_cart?(work)
+        def item_ids_in_cart
+          current_user.item_ids_in_cart
+        end
+
+        def items_in_cart
+          current_user.items_in_cart
+        end
+
+        def downloaded_works
+          current_user.downloaded_work_ids
+        end
+
+        def downloaded_items
+          current_user.downloaded_item_ids
+        end
+
+        def work_already_in_cart?(work)
           works_in_cart.include? work
+        end
+
+        # Displays items by date descending
+        def items
+          ids = @cart ? item_ids_in_cart : downloaded_items
+          order = @cart ? 'created_at DESC' : 'date_downloaded DESC'
+          CartItem.where(id: ids).order(order).page params[:page]
+        end
+
+        def item_count
+          count = @cart ? item_ids_in_cart.count : downloaded_items.count
+          count_text(count)
+        end
+
+        def count_text(count)
+          @item_count = count.to_s.concat(count == 1 ? " Item" : " Items")
+        end
+
+        def duplicates_text(duplicates)
+          if duplicates.count > 0
+            "; #{count_text(duplicates.count)}: #{duplicates.join(', ')} Already in Your Cart."
+          else
+            ''
+          end
         end
 
         def after_create_response(curation_concern)
@@ -80,11 +162,25 @@ module Morphosource
           work_to_render = (params[:work_type].downcase.concat('/show'))
         end
 
-        def count_text(items)
-          count = items.count
-          @item_count = count.to_s.concat(count == 1 ? " Item" : " Items")
+        # Using instead of search in order to get back full results instead of paginated
+        def solr_docs
+          ids = @cart ? works_in_cart : downloaded_works.uniq
+          ids.each_with_object([]){|id, docs| docs << SolrDocument.find(id)}
         end
 
+        # Get duplicates if a user tries to send them to the media cart
+        def get_duplicate_works(works, uniq_works)
+          works = works.dup
+          uniq_works.each {|id| works.slice!(works.index(id)) if works.include?(id) }
+          works
+        end
+
+        def mark_as_downloaded(items)
+          items.each do |item|
+            item.date_downloaded = Time.current
+            item.save!
+          end
+        end
      end
   end
 end

--- a/app/models/cart_item.rb
+++ b/app/models/cart_item.rb
@@ -1,3 +1,4 @@
 class CartItem < ApplicationRecord
   belongs_to :media_cart
+  paginates_per 10
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -43,7 +43,11 @@ class User < ApplicationRecord
   end
 
   def items_in_cart
-    cart_items.select{ |i| i.downloaded? == false }
+    cart_items.select{ |i| i.in_cart == true }
+  end
+
+  def item_ids_in_cart
+    items_in_cart.map{ |i| i.id }
   end
 
   def work_ids_in_cart
@@ -51,7 +55,11 @@ class User < ApplicationRecord
   end
 
   def downloaded_items
-    cart_items.select{ |i| i.downloaded? == true }
+    cart_items.select{ |i| i.date_downloaded.present? }
+  end
+
+  def downloaded_item_ids
+    downloaded_items.map{ |i| i.id }
   end
 
   def downloaded_work_ids

--- a/app/views/hyrax/base/show.html.erb
+++ b/app/views/hyrax/base/show.html.erb
@@ -6,13 +6,15 @@
   <div class="col-xs-12">
     <%= render 'work_type', presenter: @presenter %>
     <div class="pull-right">
-      <% if signed_in? %>
-        <% if @presenter.works_in_cart.include? params[:id] %>
-          <%= link_to "Item in Cart", main_app.my_cart_path, class: 'btn btn-danger' %>
-        <% else %>
-          <%= link_to "Add to Cart", main_app.add_to_cart_path(:work_id => @presenter.id, :media_cart_id => current_user.media_cart.id, :work_type => @presenter.model_name.name), class: 'btn btn-info', :method => :post %>
+      <% if @presenter.model_name.name == "Media" %>
+        <% if signed_in? %>
+          <% if @presenter.works_in_cart.include? params[:id] %>
+            <%= link_to "Item in Cart", main_app.my_cart_path, class: 'btn btn-danger' %>
+          <% else %>
+            <%= link_to "Add to Cart", main_app.add_to_cart_path(:work_id => @presenter.id, :media_cart_id => current_user.media_cart.id, :work_type => "@presenter.model_name.name"), class: 'btn btn-info', :method => :post %>
+          <% end %>
         <% end %>
-      <% end %>   
+      <% end %>
     </div>
   </div>
   <div class="col-xs-12">&nbsp;</div>

--- a/app/views/hyrax/base/show.html.erb
+++ b/app/views/hyrax/base/show.html.erb
@@ -11,7 +11,7 @@
           <% if @presenter.works_in_cart.include? params[:id] %>
             <%= link_to "Item in Cart", main_app.my_cart_path, class: 'btn btn-danger' %>
           <% else %>
-            <%= link_to "Add to Cart", main_app.add_to_cart_path(:work_id => @presenter.id, :media_cart_id => current_user.media_cart.id, :work_type => "@presenter.model_name.name"), class: 'btn btn-info', :method => :post %>
+            <%= link_to "Add to Cart", main_app.add_to_cart_path(:work_id => @presenter.id, :media_cart_id => current_user.media_cart.id, :work_type => @presenter.model_name.name), class: 'btn btn-info', :method => :post %>
           <% end %>
         <% end %>
       <% end %>

--- a/app/views/morphosource/batch_edits/_copy_selected.html.erb
+++ b/app/views/morphosource/batch_edits/_copy_selected.html.erb
@@ -1,0 +1,3 @@
+<%= form_tag(main_app.batch_create_items_path, method: :post, class: "button_to-inline", "data-behavior" => 'batch-select-all') do -%>
+  <%= submit_tag("Add Selected to Cart", class: 'batch-all-button btn btn-primary submits-batches', id:'copy-selected') %>
+<% end %>

--- a/app/views/morphosource/batch_edits/_download_all.html.erb
+++ b/app/views/morphosource/batch_edits/_download_all.html.erb
@@ -1,0 +1,11 @@
+<div class="pull-right">
+
+  <%= form_tag(main_app.batch_destroy_items_path, method: :delete, class: "button_to-inline") do -%>
+    <%= submit_tag("Clear Cart", class: 'btn btn-danger', id: 'clear-cart') %>
+  <% end %>
+
+  <%= form_tag(main_app.download_items_path, method: :get, class: "button_to-inline") do -%>
+    <%= submit_tag("Download All", class: 'btn btn-info', id: 'download-all') %>
+  <% end %>
+
+</div>

--- a/app/views/morphosource/batch_edits/_download_selected.html.erb
+++ b/app/views/morphosource/batch_edits/_download_selected.html.erb
@@ -1,0 +1,3 @@
+<%= form_tag(main_app.download_items_path, method: :get, class: "button_to-inline", "data-behavior" => 'batch-select-all') do -%>
+  <%= submit_tag("Download Selected", class: 'batch-all-button btn btn-primary submits-batches', id: 'download-selected') %>
+<% end %>

--- a/app/views/morphosource/batch_edits/_remove_selected.html.erb
+++ b/app/views/morphosource/batch_edits/_remove_selected.html.erb
@@ -1,0 +1,3 @@
+<%= form_tag(main_app.batch_destroy_items_path, method: :delete, class: "button_to-inline", "data-behavior" => 'batch-select-all') do -%>
+  <%= submit_tag("Remove Selected", class: 'batch-all-button btn btn-danger submits-batches', id: 'delete-selected') %>
+<% end %>

--- a/app/views/morphosource/batch_select/_add_button.html.erb
+++ b/app/views/morphosource/batch_select/_add_button.html.erb
@@ -1,0 +1,3 @@
+<div data-behavior="batch-add-button">
+  <%= check_box_tag "batch_document_ids[]", document.id, false, class:"batch_document_selector", id: "batch_document_#{document.id}" %>
+</div>

--- a/app/views/morphosource/batch_select/_add_button.html.erb
+++ b/app/views/morphosource/batch_select/_add_button.html.erb
@@ -1,3 +1,4 @@
-<div data-behavior="batch-add-button">
-  <%= check_box_tag "batch_document_ids[]", document.id, false, class:"batch_document_selector", id: "batch_document_#{document.id}" %>
+<!-- for Media Cart and Previous Downloads, 'batch_document_ids' are item ids -->
+<div data-behavior="batch-add-button" id="batch-add-button">
+  <%= check_box_tag "batch_document_ids[]", item.id, false, class:"batch_document_selector", id: "batch_document_#{item.id}" %>
 </div>

--- a/app/views/morphosource/my/_batch_edits_actions.html.erb
+++ b/app/views/morphosource/my/_batch_edits_actions.html.erb
@@ -1,0 +1,6 @@
+<li data-behavior="batch-edit-select-page" data-state="off">
+  <a href="#"><%= t("hyrax.dashboard.my.action.select_all") %></a>
+</li>
+<li data-behavior="batch-edit-select-none" data-state="on">
+  <a href="#"><%= t("hyrax.dashboard.my.action.select_none") %></a>
+</li>

--- a/app/views/morphosource/my/_batch_edits_actions.html.erb
+++ b/app/views/morphosource/my/_batch_edits_actions.html.erb
@@ -1,6 +1,0 @@
-<li data-behavior="batch-edit-select-page" data-state="off">
-  <a href="#"><%= t("hyrax.dashboard.my.action.select_all") %></a>
-</li>
-<li data-behavior="batch-edit-select-none" data-state="on">
-  <a href="#"><%= t("hyrax.dashboard.my.action.select_none") %></a>
-</li>

--- a/app/views/morphosource/my/_document_list.html.erb
+++ b/app/views/morphosource/my/_document_list.html.erb
@@ -1,4 +1,3 @@
-
 <div class="table-responsive" id="documents">
-  <%= render 'morphosource/my/cart_items/default_group', docs: @response.docs, items: @items %>
+  <%= render 'morphosource/my/cart_items/default_group', docs: @solr_docs, items: @items %>
 </div>

--- a/app/views/morphosource/my/_scripts.js.erb
+++ b/app/views/morphosource/my/_scripts.js.erb
@@ -1,3 +1,51 @@
 // hide or show the batch update buttons on page startup
-window.document_list_count = <%= @document_list.count %>;
+window.document_list_count = <%= @items.count %>;
 toggleButtons(<%= !@empty_batch %>);
+
+// Disable Clear Cart and Download All if cart is empty
+// Disable Batch Buttons if no items are checked
+function toggleBatchButtons () {
+  var checked = $(".batch_document_selector:checked").length;
+  if ((checked>0)) {
+    $('#download-selected').prop('disabled', false);
+    $('#delete-selected').prop('disabled', false);
+    $('#copy-selected').prop('disabled', false);
+  }
+  else {
+    $('#download-selected').prop('disabled', true);
+    $('#delete-selected').prop('disabled', true);
+    $('#copy-selected').prop('disabled', true);
+  }
+}
+
+function toggleCartButtons() {
+  var items = $(".batch_document_selector").length;
+  if ((items>0)) {
+    $('#clear-cart').prop('disabled', false);
+    $('#download-all').prop('disabled', false);
+  }
+  else {
+    $('#clear-cart').prop('disabled', true);
+    $('#download-all').prop('disabled', true);
+  }
+}
+
+Blacklight.onLoad(function() {
+  toggleBatchButtons();
+  toggleCartButtons();
+  // toggle button on or off based on boxes being clicked
+  $(".batch_document_selector").bind('click', function(e) {
+     toggleBatchButtons();
+  });
+  $('#check_all').bind('click', function(e) {
+    toggleBatchButtons();
+  });
+});
+
+$(document).on('turbolinks:load', function(){
+  toggleCartButtons();
+  // re-enable the download all button after being clicked
+  $('#download-all').bind('click', function(e) {
+     setTimeout(function(){ toggleCartButtons(); }, 500);
+  });
+});

--- a/app/views/morphosource/my/cart_items/_batch_actions.html.erb
+++ b/app/views/morphosource/my/cart_items/_batch_actions.html.erb
@@ -1,0 +1,14 @@
+<div class="batch-info">
+  <%= render 'hyrax/dashboard/collections/form_for_select_collection', user_collections: @user_collections %>
+
+  <div class="batch-toggle">
+    <% session[:batch_edit_state] = "on" %>
+    <div class="button_to-inline">
+      <%= button_to t('hyrax.dashboard.my.action.edit_selected'), hyrax.edit_batch_edits_path, method: :get, class: "btn btn-update btn-primary hidden submits-batches", data: { behavior: 'batch-edit' }, id: 'batch-edit' %>
+    </div>
+    <%= batch_delete %>
+    <%= button_tag t('hyrax.dashboard.my.action.add_to_collection'),
+        class: 'btn btn-primary submits-batches submits-batches-add',
+        data: { toggle: "modal", target: "#collection-list-container" } %>
+  </div>
+</div>

--- a/app/views/morphosource/my/cart_items/_batch_actions.html.erb
+++ b/app/views/morphosource/my/cart_items/_batch_actions.html.erb
@@ -1,14 +1,11 @@
-<div class="batch-info">
-  <%= render 'hyrax/dashboard/collections/form_for_select_collection', user_collections: @user_collections %>
-
-  <div class="batch-toggle">
+<div>
+  <div>
     <% session[:batch_edit_state] = "on" %>
-    <div class="button_to-inline">
-      <%= button_to t('hyrax.dashboard.my.action.edit_selected'), hyrax.edit_batch_edits_path, method: :get, class: "btn btn-update btn-primary hidden submits-batches", data: { behavior: 'batch-edit' }, id: 'batch-edit' %>
-    </div>
-    <%= batch_delete %>
-    <%= button_tag t('hyrax.dashboard.my.action.add_to_collection'),
-        class: 'btn btn-primary submits-batches submits-batches-add',
-        data: { toggle: "modal", target: "#collection-list-container" } %>
+    <% if @cart %>
+      <%= render 'morphosource/batch_edits/download_selected' %>
+      <%= render 'morphosource/batch_edits/remove_selected' %>
+    <% else %>
+      <%= render 'morphosource/batch_edits/copy_selected' %>
+    <% end %>
   </div>
 </div>

--- a/app/views/morphosource/my/cart_items/_default_group.html.erb
+++ b/app/views/morphosource/my/cart_items/_default_group.html.erb
@@ -4,16 +4,19 @@
   <tr>
     <th class="check-all"><label for="check_all" class="sr-only"><%= t("hyrax.dashboard.my.sr.check_all_label") %></label><%= render_check_all %></th>
     <th><%= t("hyrax.dashboard.my.heading.title") %></th>
-    <th><%= t("hyrax.dashboard.my.heading.date_uploaded") %></th>
     <th><%= t("hyrax.dashboard.my.heading.visibility") %></th>
     <th><%= t("morphosource.dashboard.my.heading.file_visibility") %></th>
-    <th><%= t("hyrax.dashboard.my.heading.action") %></th>
+    <% if @cart %>
+      <th style="width: 15%;"><%= t("hyrax.dashboard.my.heading.date_uploaded") %></th>
+    <% else %>
+      <th style="width: 15%;"><%= t("morphosource.dashboard.my.heading.date_downloaded") %></th>
+    <% end %>
   </tr>
   </thead>
   <tbody>
-  <% docs.each_with_index do |document, counter| %>
-    <% item = CartItem.where(:work_id => document.id)[0] %>
-    <%= render 'morphosource/my/cart_items/list_works', document: document, counter: counter, item: item, presenter: Hyrax::WorkShowPresenter.new(document, current_ability) %>
-  <% end %>
+    <% @items.each_with_index do |item, counter| %>
+      <% document = @solr_docs.select{|doc| doc.id == item.work_id}[0] %>
+      <%= render 'morphosource/my/cart_items/list_works', document: document, counter: counter, item: item, presenter: Hyrax::WorkShowPresenter.new(document, current_ability) %>
+    <% end %>
   </tbody>
 </table>

--- a/app/views/morphosource/my/cart_items/_list_works.html.erb
+++ b/app/views/morphosource/my/cart_items/_list_works.html.erb
@@ -2,7 +2,7 @@
 
   <td>
     <label for="batch_document_<%= document.id %>" class="sr-only"><%= t("hyrax.dashboard.my.sr.batch_checkbox") %></label>
-    <%= render 'hyrax/batch_select/add_button', document: document %>&nbsp;
+    <%= render 'morphosource/batch_select/add_button', item: item %>&nbsp;
   </td>
 
   <td>
@@ -28,21 +28,23 @@
       </div>
     </div>
   </td>
-  <!-- Date Cart Item was created -->
-    <td class="date"><%= item.created_at.strftime("%Y-%m-%d") %></td>
-    <td><%= render_visibility_link document %></td>
-    <td>
-      <div style="display:flex; flex-direction: column; justify-content: space-around; align-items: flex-start;">
-        <% unless document.file_set_visibilities.nil? %>
-          <% document.file_set_visibilities.each do |visibility| %>
-            <%= visibility_badge(visibility) %>
-            <div style="height: 3px;"></div>
-          <% end %>
+  <td><%= render_visibility_link document %></td>
+  <td>
+    <div style="display:flex; flex-direction: column; justify-content: space-around; align-items: flex-start;">
+      <% unless document.file_set_visibilities.nil? %>
+        <% document.file_set_visibilities.each do |visibility| %>
+          <%= render_visibility_link document %>
+          <div style="height: 3px;"></div>
         <% end %>
-      </div>
-    </td>
-    <!-- Delete Cart Item -->
-    <td>
-      <%= link_to "Remove", main_app.remove_from_cart_path(item), class: 'btn btn-sm btn-danger delete', :method => :delete %>
-    </td>
-  </tr>
+      <% end %>
+    </div>
+  </td>
+
+  <% if @cart %>
+    <!-- Date Cart Item was created -->
+    <td class="date"><%= item.created_at.strftime("%Y-%m-%d") %></td>
+  <% else %>
+    <!-- Date Cart Item was downloaded -->
+    <td class="date"><%= item.date_downloaded.strftime("%Y-%m-%d") %></td>
+  <% end %>
+</tr>

--- a/app/views/morphosource/my/cart_items/_results_pagination.html.erb
+++ b/app/views/morphosource/my/cart_items/_results_pagination.html.erb
@@ -1,9 +1,7 @@
-<% if @response.total_pages > 1 %>
- <div class="row record-padding">
-  <div class="col-md-9">
-    <div class="pagination">
-      <%= paginate @response, outer_window: 2, theme: 'blacklight' %>
-    </div>
-  </div>
+<div class="row record-padding">
+ <div class="col-md-9">
+   <div class="pagination">
+     <%= paginate @items, outer_window: 2, theme: 'blacklight' %>
+   </div>
  </div>
-<% end %>
+</div>

--- a/app/views/morphosource/my/cart_items/index.html.erb
+++ b/app/views/morphosource/my/cart_items/index.html.erb
@@ -22,12 +22,12 @@
       <% if @cart %>
         <span class="fa fa-shopping-cart" aria-hidden="true"></span>
         Media Cart ( <%= @item_count %> )
+        <%= render 'morphosource/batch_edits/download_all' %>
       <% else %>
         <span class="fa fa-download" aria-hidden="true"></span>
         Downloads ( <%= @item_count %> )
       <% end %>
     </h1>
-    <div class="pull-right"></div>
   </div>
 </div>
 
@@ -39,6 +39,7 @@
 
 <div class="panel-body">
   <h2 class="sr-only">Works listing</h2>
+  <%= render 'batch_actions' %>
   <%= render 'morphosource/my/document_list' %>
-  <%= render 'morphosource/my/cart_items/results_pagination' %>
+  <%= render 'results_pagination' %>
 </div>

--- a/config/locales/morphosource.en.yml
+++ b/config/locales/morphosource.en.yml
@@ -12,6 +12,7 @@ en:
       my:
         heading:
           file_visibility: 'File Visibility'
+          date_downloaded: 'Date Downloaded'
     validation:
       missing:
         title: 'Your work must have a title.'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,7 @@ Rails.application.routes.draw do
   mount Hyrax::Engine, at: '/'
   resources :welcome, only: 'index'
   root 'hyrax/homepage#index'
-  
+
   namespace :hyrax, path: :concern do
     namespaced_resources 'media' do
       collection do
@@ -73,7 +73,9 @@ Rails.application.routes.draw do
       get 'dashboard/my/downloads', action: :previous_downloads, controller: :cart_items, as: 'my_downloads'
       get 'dashboard/my/cart', action: :media_cart, controller: :cart_items, as: 'my_cart'
       post 'add_to_cart', action: :create, controller: :cart_items
-      delete '/cart_items/:id', to: 'cart_items#destroy', as: 'remove_from_cart'
+      post 'batch_create_items', action: :batch_create, controller: :cart_items
+      delete '/cart_items', action: :batch_destroy, controller: :cart_items, as: 'batch_destroy_items'
+      get 'download_items', action: :download, controller: :cart_items, as: 'download_items'
     end
   end
 

--- a/db/migrate/20190220151203_add_date_downloaded_to_cart_items.rb
+++ b/db/migrate/20190220151203_add_date_downloaded_to_cart_items.rb
@@ -1,0 +1,5 @@
+class AddDateDownloadedToCartItems < ActiveRecord::Migration[5.1]
+  def change
+    add_column :cart_items, :date_downloaded, :datetime
+  end
+end

--- a/db/migrate/20190301152534_add_in_cart_to_cart_items.rb
+++ b/db/migrate/20190301152534_add_in_cart_to_cart_items.rb
@@ -1,0 +1,5 @@
+class AddInCartToCartItems < ActiveRecord::Migration[5.1]
+  def change
+    add_column :cart_items, :in_cart, :boolean, default: true
+  end
+end

--- a/db/migrate/20190306225507_remove_downloaded_from_cart_items.rb
+++ b/db/migrate/20190306225507_remove_downloaded_from_cart_items.rb
@@ -1,0 +1,5 @@
+class RemoveDownloadedFromCartItems < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :cart_items, :downloaded, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190211161505) do
+ActiveRecord::Schema.define(version: 20190306225507) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -30,9 +30,10 @@ ActiveRecord::Schema.define(version: 20190211161505) do
   create_table "cart_items", force: :cascade do |t|
     t.integer "media_cart_id", null: false
     t.string "work_id", null: false
-    t.boolean "downloaded", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "date_downloaded"
+    t.boolean "in_cart", default: true
     t.index ["media_cart_id"], name: "index_cart_items_on_media_cart_id"
     t.index ["work_id"], name: "index_cart_items_on_work_id"
   end

--- a/spec/controllers/morphosource/my/cart_items_controller_spec.rb
+++ b/spec/controllers/morphosource/my/cart_items_controller_spec.rb
@@ -9,32 +9,49 @@ RSpec.describe Morphosource::My::CartItemsController, :type => :controller  do
   # Work already added to cart
   let(:work)          { Media.create(id: "aaa", title: ["Test Media Work"])}
   # Work not yet added to cart
-  let(:work2)         { Media.create(id: "fff", title: ["Test Media Work"])}
+  let(:work22)         { Media.create(id: "zzz", title: ["Test Media Work"])}
 
   let(:current_user)  { User.create(id: 1, email: "example@email.com", password: "password") }
   let(:media_cart)    { MediaCart.where(user_id: current_user.id)[0] }
-  let(:cartItem1)     { CartItem.create( media_cart_id: media_cart.id, work_id: "aaa") }
-  let(:cartItem2)     { CartItem.create( media_cart_id: media_cart.id, work_id: "bbb") }
-  let(:cartItem3)     { CartItem.create( media_cart_id: media_cart.id, work_id: "ccc") }
-  let(:cartItem4)     { CartItem.create( media_cart_id: media_cart.id, work_id: "ddd", downloaded: true) }
-  let(:cartItem5)     { CartItem.create( media_cart_id: media_cart.id, work_id: "eee", downloaded: true) }
+  let(:cartItem1)     { CartItem.create( media_cart_id: media_cart.id, work_id: "aaa", in_cart: true, date_downloaded: nil) }
+  let(:cartItem2)     { CartItem.create( media_cart_id: media_cart.id, work_id: "bbb", in_cart: true, date_downloaded: nil) }
+  let(:cartItem3)     { CartItem.create( media_cart_id: media_cart.id, work_id: "ccc", in_cart: true, date_downloaded: nil) }
+  let(:cartItem4)     { CartItem.create( media_cart_id: media_cart.id, work_id: "ddd", in_cart: true, date_downloaded: Time.current) }
+  let(:cartItem5)     { CartItem.create( media_cart_id: media_cart.id, work_id: "eee", in_cart: false, date_downloaded: Time.current) }
+  let(:cartItem6)     { CartItem.create( media_cart_id: media_cart.id, work_id: "fff", in_cart: false, date_downloaded: Time.current) }
 
-  let(:allCartItems)  { [cartItem1, cartItem2, cartItem3, cartItem4, cartItem5] }
+
+  let(:allCartItems)  { [cartItem1, cartItem2, cartItem3, cartItem4, cartItem5, cartItem6] }
+
+  let(:doc1)          { SolrDocument.new(id: "aaa") }
+  let(:doc2)          { SolrDocument.new(id: "bbb") }
+  let(:doc3)          { SolrDocument.new(id: "ccc") }
+  let(:doc4)          { SolrDocument.new(id: "ddd") }
+  let(:doc5)          { SolrDocument.new(id: "eee") }
+  let(:doc6)          { SolrDocument.new(id: "fff") }
 
   before do
     allCartItems.each{ |i| i.touch }
     sign_in current_user
   end
 
-  describe "#search_builder_class" do
+  describe "#" do
+    before do
+      allow(SolrDocument).to receive(:find).with(cartItem1.work_id).and_return(doc1)
+      allow(SolrDocument).to receive(:find).with(cartItem2.work_id).and_return(doc2)
+      allow(SolrDocument).to receive(:find).with(cartItem3.work_id).and_return(doc3)
+      allow(SolrDocument).to receive(:find).with(cartItem4.work_id).and_return(doc4)
+      allow(SolrDocument).to receive(:find).with(cartItem5.work_id).and_return(doc5)
+      allow(SolrDocument).to receive(:find).with(cartItem6.work_id).and_return(doc6)
+    end
 
     context "user views the media cart" do
       before do
         get :media_cart
       end
 
-      it 'returns the CartItems Search Builder' do
-        expect(subject.search_builder_class).to eq (Morphosource::My::CartItems::CartItemsSearchBuilder)
+      it 'returns documents for works in the media cart' do
+        expect(subject.send(:solr_docs)).to match_array([doc1,doc2,doc3,doc4])
       end
     end
 
@@ -43,23 +60,22 @@ RSpec.describe Morphosource::My::CartItemsController, :type => :controller  do
         get :previous_downloads
       end
 
-      it 'returns the Downloads Search Builder' do
-        expect(subject.search_builder_class).to eq (Morphosource::My::CartItems::DownloadsSearchBuilder)
+      it 'returns documents for previously downloaded works' do
+        expect(subject.send(:solr_docs)).to match_array([doc4,doc5,doc6])
       end
     end
   end
 
   describe "#works_in_cart" do
-
     it "returns only cart items that have not yet been downloaded" do
-      expect(subject.send(:works_in_cart)).to match_array(["aaa","bbb","ccc"])
+      expect(subject.send(:works_in_cart)).to match_array(["aaa","bbb","ccc","ddd"])
     end
   end
 
   describe "#create" do
 
     context 'item is not in cart' do
-      let(:post_params) { {:media_cart_id => media_cart.id, :work_id => work2.id, :work_type => "Media"} }
+      let(:post_params) { {:media_cart_id => media_cart.id, :work_id => work22.id, :work_type => "Media"} }
 
       it "creates a new CartItem" do
         expect{
@@ -88,17 +104,108 @@ RSpec.describe Morphosource::My::CartItemsController, :type => :controller  do
       end
     end
 
-    describe "#destroy" do
+    describe "#batch_destroy" do
 
-      it "deletes the cart item" do
+      it "deletes the cart item if it hasn't been downloaded" do
         expect{
-          process :destroy, method: :delete, params: {:id => cartItem1.id}
+          process :batch_destroy, method: :delete, params: {:batch_document_ids => [cartItem1.id]}
         }.to change{CartItem.count}.by(-1)
       end
 
+      it "removes the cart item from the cart, but doesn't delete if it has been downloaded" do
+        expect{
+          process :batch_destroy, method: :delete, params: {:batch_document_ids => [cartItem4.id]}
+        }.to change{CartItem.count}.by(0)
+        delete :batch_destroy, params: {:batch_document_ids => [cartItem4.id]}
+        cartItem4.reload
+        expect(cartItem4.in_cart).to eq(false)
+      end
+
       it "returns flash message 'Item Removed from Cart'" do
-        delete :destroy, params: {:id => cartItem1.id}
-        expect(response.flash[:notice]).to eq('Item Removed from Cart')
+        delete :batch_destroy, params: {:batch_document_ids => [cartItem1.id]}
+        expect(response.flash[:notice]).to eq('1 Item Removed from Cart')
+      end
+    end
+  end
+
+  describe "#batch_create" do
+    context "the work is not already in the cart" do
+      let(:work5) { Media.new(id: "eee", title: ["Test Work Title"]) }
+      let(:work6) { Media.new(id: "fff", title: ["Test Work Title"]) }
+
+      before do
+        allow(Media).to receive(:find).with(cartItem5.work_id).and_return(work5)
+        allow(Media).to receive(:find).with(cartItem6.work_id).and_return(work6)
+      end
+
+      it "creates new cart items" do
+        expect{
+          process :batch_create, method: :get, params: {:batch_document_ids => [cartItem5.id, cartItem6.id]}
+        }.to change{CartItem.count}.by(2)
+      end
+
+      it "displays a flash message" do
+        get :batch_create, params: {:batch_document_ids => [cartItem5.id, cartItem6.id]}
+        expect(response.flash[:notice]).to eq("2 Items Added to Cart")
+      end
+    end
+
+    context "the work is already in the cart" do
+      let(:cartItem7)     { CartItem.create( media_cart_id: media_cart.id, work_id: "aaa", in_cart: false, date_downloaded: Time.current) }
+      let(:cartItem8)     { CartItem.create( media_cart_id: media_cart.id, work_id: "bbb", in_cart: false, date_downloaded: Time.current) }
+      let(:work2) { Media.new(id: "bbb", title: ["Test Work Title"]) }
+
+      before do
+        allow(Media).to receive(:find).with(cartItem7.work_id).and_return(work)
+        allow(Media).to receive(:find).with(cartItem8.work_id).and_return(work2)
+      end
+
+      it "does not create new cart items" do
+        expect{
+          process :batch_create, method: :get, params: {:batch_document_ids => [cartItem7.id, cartItem8.id]}
+        }.to change{CartItem.count}.by(0)
+      end
+
+      it "displays a flash message" do
+        get :batch_create, params: {:batch_document_ids => [cartItem7.id, cartItem8.id]}
+        expect(response.flash[:notice]).to eq("0 Items Added to Cart; 2 Items: Test Media Work, Test Work Title Already in Your Cart.")
+      end
+    end
+  end
+
+  describe '#download' do
+    context "the user uses batch-select to select several cart items" do
+      before do
+        get :download, params: { batch_document_ids: [cartItem1.id, cartItem2.id] }
+      end
+      it "sets the items' date_downloaded" do
+        [cartItem1, cartItem2].each(&:reload)
+        expect(cartItem1.date_downloaded.to_date).to eq(Time.now.to_date)
+        expect(cartItem2.date_downloaded.to_date).to eq(Time.now.to_date)
+      end
+      it "does not change the date downloaded for unselected items in the cart" do
+        [cartItem3, cartItem4].each(&:reload)
+        expect(cartItem3.date_downloaded).to eq(nil)
+      end
+      it "redirects to media/#zip with the work ids as params" do
+        work_ids = [cartItem1.work_id, cartItem2.work_id]
+        expect(response).to redirect_to(zip_hyrax_media_index_path(ids: work_ids))
+      end
+    end
+    context "the user clicks the 'download all' button" do
+      before do
+        get :download, params: {}
+      end
+      it "sets the date_downloaded for all the items in the user's cart" do
+        [cartItem1, cartItem2, cartItem3, cartItem4].each(&:reload)
+        expect(cartItem1.date_downloaded.to_date).to eq(Time.now.to_date)
+        expect(cartItem2.date_downloaded.to_date).to eq(Time.now.to_date)
+        expect(cartItem3.date_downloaded.to_date).to eq(Time.now.to_date)
+        expect(cartItem4.date_downloaded.to_date).to eq(Time.now.to_date)
+      end
+      it "redirects to media/#zip with the work ids as params" do
+        work_ids = [cartItem1.work_id, cartItem2.work_id, cartItem3.work_id, cartItem4.work_id]
+        expect(response).to redirect_to(zip_hyrax_media_index_path(ids: work_ids))
       end
     end
   end

--- a/spec/controllers/morphosource/my/cart_items_controller_spec.rb
+++ b/spec/controllers/morphosource/my/cart_items_controller_spec.rb
@@ -189,7 +189,9 @@ RSpec.describe Morphosource::My::CartItemsController, :type => :controller  do
       end
       it "redirects to media/#zip with the work ids as params" do
         work_ids = [cartItem1.work_id, cartItem2.work_id]
-        expect(response).to redirect_to(zip_hyrax_media_index_path(ids: work_ids))
+        redirect_params = Rack::Utils.parse_query(URI.parse(response.location).query)
+        expect(response).to redirect_to %r(\Ahttp://test.host/concern/media/zip?)
+        expect(redirect_params["ids[]"]).to match_array(work_ids)
       end
     end
     context "the user clicks the 'download all' button" do
@@ -205,7 +207,9 @@ RSpec.describe Morphosource::My::CartItemsController, :type => :controller  do
       end
       it "redirects to media/#zip with the work ids as params" do
         work_ids = [cartItem1.work_id, cartItem2.work_id, cartItem3.work_id, cartItem4.work_id]
-        expect(response).to redirect_to(zip_hyrax_media_index_path(ids: work_ids))
+        redirect_params = Rack::Utils.parse_query(URI.parse(response.location).query)
+        expect(response).to redirect_to %r(\Ahttp://test.host/concern/media/zip?)
+        expect(redirect_params["ids[]"]).to match_array(work_ids)
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2,13 +2,13 @@ require 'rails_helper'
 
 RSpec.describe User, type: :model do
 
-  let(:user)  { User.create(id: 1, email: "example@email.com", password: "password") }
+  let(:user)  { User.create(email: "example@email.com", password: "password") }
   let(:media_cart)    { MediaCart.where(user_id: user.id)[0] }
-  let(:cartItem1)     { CartItem.create(id: 1, media_cart_id: media_cart.id, work_id: "aaa") }
-  let(:cartItem2)     { CartItem.create(id: 2, media_cart_id: media_cart.id, work_id: "bbb") }
-  let(:cartItem3)     { CartItem.create(id: 3, media_cart_id: media_cart.id, work_id: "ccc") }
-  let(:cartItem4)     { CartItem.create(id: 4, media_cart_id: media_cart.id, work_id: "ddd", downloaded: true) }
-  let(:cartItem5)     { CartItem.create(id: 5, media_cart_id: media_cart.id, work_id: "eee", downloaded: true) }
+  let(:cartItem1)     { CartItem.create(id: 1, media_cart_id: media_cart.id, work_id: "aaa", in_cart: true) }
+  let(:cartItem2)     { CartItem.create(id: 2, media_cart_id: media_cart.id, work_id: "bbb", in_cart: true) }
+  let(:cartItem3)     { CartItem.create(id: 3, media_cart_id: media_cart.id, work_id: "ccc", in_cart: true) }
+  let(:cartItem4)     { CartItem.create(id: 4, media_cart_id: media_cart.id, work_id: "ddd", in_cart: false, date_downloaded: Time.current) }
+  let(:cartItem5)     { CartItem.create(id: 5, media_cart_id: media_cart.id, work_id: "eee", in_cart: false, date_downloaded: Time.current) }
 
   let(:allCartItems)  { [cartItem1, cartItem2, cartItem3, cartItem4, cartItem5] }
 

--- a/spec/routing/cart_items_routing_spec.rb
+++ b/spec/routing/cart_items_routing_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe 'cart items routing', type: :routing do
+
+  it 'has a route for my downloads page' do
+    route = { controller: 'morphosource/my/cart_items', action: 'previous_downloads' }
+    expect(:get => 'dashboard/my/downloads').to route_to(route)
+  end
+
+  it 'has a route for my media cart page' do
+    route = { controller: 'morphosource/my/cart_items', action: 'media_cart' }
+    expect(:get => 'dashboard/my/cart').to route_to(route)
+  end
+
+  it 'has a route to add a work to the media cart' do
+    route = { controller: 'morphosource/my/cart_items', action: 'create' }
+    expect(:post => 'add_to_cart').to route_to(route)
+  end
+
+  it 'has a route to copy items from the downloads page to the shopping cart' do
+    route = { controller: 'morphosource/my/cart_items', action: 'batch_create' }
+    expect(:post => 'batch_create_items').to route_to(route)
+  end
+
+  it 'has a route to batch destroy cart items' do
+    route = { controller: 'morphosource/my/cart_items', action: 'batch_destroy' }
+    expect(:delete => '/cart_items').to route_to(route)
+  end
+
+  it 'has a route to download cart items' do
+    route = { controller: 'morphosource/my/cart_items', action: 'download' }
+    expect(:get => 'download_items').to route_to(route)
+  end
+
+end


### PR DESCRIPTION
- Uses media/#zip to create zip files for works represented by media cart items.
- Can download one, multiple, or all works in the media cart.
- the Previous Downloads page provides a list of works downloaded by the user.
- Works can be copied from the previously downloaded page to the media cart to be downloaded again.
- Users can delete one, multiple, or all items in their media cart.