### PR TITLE
"Synchotron" should instead be "Synchrotron"

### DIFF
--- a/config/authorities/modalities.yml
+++ b/config/authorities/modalities.yml
@@ -13,8 +13,8 @@ terms:
   - id: PositronEmissionTomography
     term: Positron Emission Tomography (PET)
     active: true
-  - id: SynchotronImaging
-    term: Synchotron Imaging
+  - id: SynchrotronImaging
+    term: Synchrotron Imaging
     active: true
   - id: NeutrinoImaging
     term: Neutrino Imaging


### PR DESCRIPTION
This probably needs to be updated on <https://www.idigbio.org/wiki/index.php/3D_Scan_Modality_Subtypes> as well - not sure if there's a more involved process there, but probably good to fix this before it goes "live".