### PR TITLE
MR-449: update title formulas for Media, BSO, and CHO

### DIFF
--- a/app/models/biological_specimen.rb
+++ b/app/models/biological_specimen.rb
@@ -1,6 +1,7 @@
 class BiologicalSpecimen < Morphosource::Works::Base
   include ::Hyrax::WorkBehavior
   validates_with Morphosource::ParentChildValidator
+  after_create :add_id_to_title
 
   self.indexer = BiologicalSpecimenIndexer
   # Change this to restrict which works can be added as a child.
@@ -15,4 +16,10 @@ class BiologicalSpecimen < Morphosource::Works::Base
   # This must be included at the end, because it finalizes the metadata
   # schema (by adding accepts_nested_attributes)
   include ::Hyrax::BasicMetadata
+
+  private
+    def add_id_to_title
+      self.title.set("S#{self.id.to_s}: #{self.title.first.to_s}")
+      self.save!
+    end
 end

--- a/app/models/cultural_heritage_object.rb
+++ b/app/models/cultural_heritage_object.rb
@@ -1,6 +1,7 @@
 class CulturalHeritageObject < Morphosource::Works::Base
   include ::Hyrax::WorkBehavior
   validates_with Morphosource::ParentChildValidator
+  after_create :add_id_to_title
 
   self.indexer = CulturalHeritageObjectIndexer
   # Change this to restrict which works can be added as a child.
@@ -15,4 +16,10 @@ class CulturalHeritageObject < Morphosource::Works::Base
   # This must be included at the end, because it finalizes the metadata
   # schema (by adding accepts_nested_attributes)
   include ::Hyrax::BasicMetadata
+
+  private
+    def add_id_to_title
+      self.title.set("C#{self.id.to_s}: #{self.title.first.to_s}")
+      self.save!
+    end
 end

--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -1,6 +1,7 @@
 class Media < Morphosource::Works::Base
   include ::Hyrax::WorkBehavior
   validates_with Morphosource::ParentChildValidator
+  after_create :add_id_to_title
 
   self.work_requires_files = true
 
@@ -41,4 +42,10 @@ class Media < Morphosource::Works::Base
     # order unique visibilities in the order that they appear on the work form.
     all_visibilities & file_visibilities
   end
+
+  private
+    def add_id_to_title
+      self.title.set("M#{self.id.to_s}: #{self.title.first.to_s}")
+      self.save!
+    end
 end

--- a/spec/controllers/morphosource/my/cart_items_controller_spec.rb
+++ b/spec/controllers/morphosource/my/cart_items_controller_spec.rb
@@ -168,7 +168,7 @@ RSpec.describe Morphosource::My::CartItemsController, :type => :controller  do
 
       it "displays a flash message" do
         get :batch_create, params: {:batch_document_ids => [cartItem7.id, cartItem8.id]}
-        expect(response.flash[:notice]).to eq("0 Items Added to Cart; 2 Items: Test Media Work, Test Work Title Already in Your Cart.")
+        expect(response.flash[:notice]).to eq("0 Items Added to Cart; 2 Items: Maaa: Test Media Work, Test Work Title Already in Your Cart.")
       end
     end
   end

--- a/spec/presenters/hyrax/media_presenter_spec.rb
+++ b/spec/presenters/hyrax/media_presenter_spec.rb
@@ -113,6 +113,7 @@ RSpec.describe Hyrax::MediaPresenter do
   describe "sample Media work" do
     subject(:presenter) { described_class.new(SolrDocument.new(work.to_solr), nil) }
 
+    let(:id)                { 'aaa' }
     let(:title)             {['Media Work Title']}
     let(:publisher)         {['Random House']}
     let(:identifier)        {['123ABC']}
@@ -139,7 +140,8 @@ RSpec.describe Hyrax::MediaPresenter do
     let(:user)              { 'test@example.com' }
 
     let :work do
-      Media.create(title:            title,
+      Media.create(id:               id,
+                   title:            title,
                    publisher:        publisher,
                    identifier:       identifier,
                    keyword:          keyword,
@@ -165,7 +167,7 @@ RSpec.describe Hyrax::MediaPresenter do
                    depositor:        user)
     end
 
-    it { is_expected.to have_attributes(title: title, publisher: publisher, identifier: identifier, keyword: keyword, date_created: date_created, related_url: related_url, rights_statement: rights_statement, agreement_uri: agreement_uri, cite_as: cite_as, funding: funding, map_type: map_type, media_type:  media_type, modality: modality, orientation: orientation, part: part, rights_holder: rights_holder,
+    it { is_expected.to have_attributes(title: ["M#{id}: #{title.first}"], publisher: publisher, identifier: identifier, keyword: keyword, date_created: date_created, related_url: related_url, rights_statement: rights_statement, agreement_uri: agreement_uri, cite_as: cite_as, funding: funding, map_type: map_type, media_type:  media_type, modality: modality, orientation: orientation, part: part, rights_holder: rights_holder,
     scale_bar: scale_bar, side: side, unit: unit, x_spacing: x_spacing, y_spacing: y_spacing, z_spacing: z_spacing) }
   end
 end


### PR DESCRIPTION
We can't access the id from the Hyrax actor context, because the ID isn't generated until after the object is saved in Fedora. By using the `after_create` callback chain instead, we can update the title to prefix the title with the generated id only when the object is first created (after it's been saved in Fedora so that the id is present).