### PR TITLE
MR-448: Auto-generate titles for Imaging/Processing Events

### DIFF
--- a/app/actors/hyrax/actors/imaging_event_actor.rb
+++ b/app/actors/hyrax/actors/imaging_event_actor.rb
@@ -3,6 +3,40 @@
 module Hyrax
   module Actors
     class ImagingEventActor < Hyrax::Actors::BaseActor
+      def create(env)
+        env.attributes['title'] = [ generated_title(env) ]
+        super
+      end
+
+      def update(env)
+        env.attributes['title'] = [ generated_title(env) ]
+        super
+      end
+
+      def generated_title(env)
+        # <device parent manufacturer> <device parent name> <modality> Imaging Event (<date created>)
+        # For device parent fields and modality field, blank if no value
+        # For date created, if no value should be “(No Event Date)”
+        attrs = env.attributes
+        work_parents = ''
+        if attrs['work_parents_attributes'].present?
+          attrs['work_parents_attributes'].each do |key, wp|
+            work_parent = Morphosource::Works::Base.find(wp['id'])
+            work_parent_string = case work_parent.class.to_s
+              when 'Device'
+                "#{work_parent.creator.first} #{work_parent.title.first}"
+              # when 'BiologicalSpecimen'
+              #   "S#{wp['id']} "
+              # when 'CulturalHeritageObject'
+              #   "C#{wp['id']} "
+            end
+            work_parents += "#{work_parent_string} "
+          end
+        end
+        date_created = attrs['date_created'].present? ? attrs['date_created'].first : 'No Event Date'
+        modality = attrs['modality'].present? ? "#{attrs['modality'].first} " : ''
+        "#{work_parents}#{modality}Imaging Event (#{date_created})"
+      end
     end
   end
 end

--- a/app/actors/hyrax/actors/processing_event_actor.rb
+++ b/app/actors/hyrax/actors/processing_event_actor.rb
@@ -3,6 +3,37 @@
 module Hyrax
   module Actors
     class ProcessingEventActor < Hyrax::Actors::BaseActor
+      def create(env)
+        env.attributes['title'] = [ generated_title(env) ]
+        super
+      end
+
+      def update(env)
+        env.attributes['title'] = [ generated_title(env) ]
+        super
+      end
+
+      def generated_title(env)
+        # M<media parent hyrax ID> <media parent modality> Processing Event (<date created>)
+        # For media parent fields, blank if no value
+        # For date created, if no value should be “(No Event Date)”
+        attrs = env.attributes
+        work_parents = ''
+        if attrs['work_parents_attributes'].present?
+          attrs['work_parents_attributes'].each do |key, wp|
+            work_parent = Morphosource::Works::Base.find(wp['id'])
+            work_parent_string = case work_parent.class.to_s
+              when 'Media'
+                "M#{wp['id']} #{work_parent.modality.first}"
+              # when 'ImagingEvent'
+              #   "IE#{wp['id']} #{work_parent.ie_modality.first}"
+            end
+            work_parents += "#{work_parent_string} "
+          end
+        end
+        date_created = attrs['date_created'].present? ? attrs['date_created'].first : 'No Event Date'
+        "#{work_parents}Processing Event (#{date_created})"
+      end
     end
   end
 end

--- a/app/models/imaging_event.rb
+++ b/app/models/imaging_event.rb
@@ -1,6 +1,7 @@
 class ImagingEvent < Morphosource::Works::Base
   include ::Hyrax::WorkBehavior
   validates_with Morphosource::ParentChildValidator
+  after_create :add_id_to_title
 
   self.work_requires_files = false
   self.indexer = ImagingEventIndexer
@@ -24,4 +25,9 @@ class ImagingEvent < Morphosource::Works::Base
 #    index.as :stored_searchable
  # end
 
+  private
+    def add_id_to_title
+      self.title.set("IE#{self.id.to_s}: #{self.title.first.to_s}")
+      self.save!
+    end
 end

--- a/app/models/processing_event.rb
+++ b/app/models/processing_event.rb
@@ -1,6 +1,7 @@
 class ProcessingEvent < Morphosource::Works::Base
   include ::Hyrax::WorkBehavior
   validates_with Morphosource::ParentChildValidator
+  after_create :add_id_to_title
 
   self.indexer = ProcessingEventIndexer
   # Change this to restrict which works can be added as a child.
@@ -13,4 +14,10 @@ class ProcessingEvent < Morphosource::Works::Base
   # This must be included at the end, because it finalizes the metadata
   # schema (by adding accepts_nested_attributes)
   include ::Hyrax::BasicMetadata
+
+  private
+    def add_id_to_title
+      self.title.set("PE#{self.id.to_s}: #{self.title.first.to_s}")
+      self.save!
+    end
 end

--- a/spec/presenters/hyrax/imaging_event_presenter_spec.rb
+++ b/spec/presenters/hyrax/imaging_event_presenter_spec.rb
@@ -43,9 +43,11 @@ RSpec.describe Hyrax::ImagingEventPresenter do
 
     let(:visibility)              { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
     let(:user)                    { 'test@example.com' }
+    let(:id)                      { 'aaa' }
 
     let :work do
         ImagingEvent.create(
+            id: id,
             description: description,
             creator: creator,
             title: title,
@@ -87,7 +89,7 @@ RSpec.describe Hyrax::ImagingEventPresenter do
   it { is_expected.to have_attributes(
             description: description,
             creator: creator,
-            title: title,
+            title: ["IE#{id}: #{title.first}"],
             software: software,
             ie_modality: ie_modality,
 


### PR DESCRIPTION
As noted on the ticket, these can have other parent work types that weren't specified to be in the title. The code paths for adding these to the titles have been left commented out.