### PR TITLE
MR-457: add a processing_activity field to Processing Events

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -149,6 +149,9 @@ class CatalogController < ApplicationController
     config.add_show_field solr_name('cho_type', :stored_searchable)
     config.add_show_field solr_name('material', :stored_searchable)
     config.add_show_field solr_name('short_title', :stored_searchable)
+    
+    # Processing Events
+    config.add_show_field solr_name('processing_activity', :stored_searchable)
 
     # "fielded" search configuration. Used by pulldown among other places.
     # For supported keys in hash, see rdoc for Blacklight::SearchFields

--- a/app/forms/hyrax/processing_event_form.rb
+++ b/app/forms/hyrax/processing_event_form.rb
@@ -17,7 +17,12 @@ module Hyrax
       [#creator,
       #:date_created,
       #:description,
-      :software]
+      :software,
+      :processing_activity,
+      :processing_activity_type,
+      :processing_activity_software,
+      :processing_activity_description
+    ]
 
     self.terms -=
       [:based_near,
@@ -45,10 +50,7 @@ module Hyrax
     self.required_fields = []
 
     def primary_terms
-      required_fields + [:creator, :date_created, :software, :description]
+      required_fields + [:creator, :date_created, :software, :description, :processing_activity, :processing_activity_type, :processing_activity_software, :processing_activity_description]
     end
-
-
-
   end
 end

--- a/app/models/concerns/morphosource/processing_event_metadata.rb
+++ b/app/models/concerns/morphosource/processing_event_metadata.rb
@@ -10,6 +10,17 @@ module Morphosource
       index.as :stored_searchable
     end
 
+    property :processing_activity_type, predicate: ::RDF::URI.new("https://www.morphosource.org/terms/processingActivityType") do |index|
+      index.as :stored_searchable
+    end
+
+    property :processing_activity_software, predicate: ::RDF::URI.new("http://dublincore.org/documents/dcmi-terms/#dcmitype-Software") do |index|
+      index.as :stored_searchable
+    end
+
+    property :processing_activity_description, predicate: ::RDF::URI.new("https://www.morphosource.org/terms/processingActivityDescription") do |index|
+      index.as :stored_searchable
+    end
   end
   
   end

--- a/app/models/concerns/morphosource/processing_event_metadata.rb
+++ b/app/models/concerns/morphosource/processing_event_metadata.rb
@@ -10,6 +10,10 @@ module Morphosource
       index.as :stored_searchable
     end
 
+    property :processing_activity, predicate: ::RDF::URI.new("http://rs.tdwg.org/ac/terms/resourceCreationTechnique") do |index|
+      index.as :stored_searchable
+    end
+
     property :processing_activity_type, predicate: ::RDF::URI.new("https://www.morphosource.org/terms/processingActivityType") do |index|
       index.as :stored_searchable
     end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -147,6 +147,25 @@ class SolrDocument
     self[Solrizer.solr_name('current_location', :stored_searchable)]
   end
 
+  def processing_activity
+    Rails.logger.info("Processing Activity: #{processing_activity_type.inspect} #{processing_activity_software.inspect} #{processing_activity_description.inspect}")
+    processing_activity_type.map.with_index do |item, index|
+      "Activity Type: #{item}, Software: #{processing_activity_software[index]}, Activity Description: #{processing_activity_description[index]}"
+    end
+  end
+
+  def processing_activity_type
+    self[Solrizer.solr_name('processing_activity_type', :stored_searchable)]
+  end
+
+  def processing_activity_software
+    self[Solrizer.solr_name('processing_activity_software', :stored_searchable)]
+  end
+
+  def processing_activity_description
+    self[Solrizer.solr_name('processing_activity_description', :stored_searchable)]
+  end
+
   def geographic_coordinates
     if (latitude && longitude)
       "Latitude: " + latitude[0] + ", Longitude: " + longitude[0]
@@ -384,19 +403,14 @@ class SolrDocument
     self[Solrizer.solr_name('facility', :stored_searchable)]
   end
 
-  # Processing Event
+  # Processing Event & Image Capture Event
   def software
     self[Solrizer.solr_name('software', :stored_searchable)]
   end
 
-
   # Image Capture Event
   def ie_modality
       self[Solrizer.solr_name('ie_modality', :stored_searchable)]
-  end
-
-  def software
-      self[Solrizer.solr_name('software', :stored_searchable)]
   end
 
   def exposure_time

--- a/app/presenters/hyrax/processing_event_presenter.rb
+++ b/app/presenters/hyrax/processing_event_presenter.rb
@@ -4,6 +4,6 @@ module Hyrax
   class ProcessingEventPresenter < Hyrax::WorkShowPresenter
     include Morphosource::PresenterMethods
 
-    delegate :software, to: :solr_document
+    delegate :software, :processing_activity, to: :solr_document
   end
 end

--- a/app/services/morphosource/processing_activity_types_service.rb
+++ b/app/services/morphosource/processing_activity_types_service.rb
@@ -1,0 +1,18 @@
+# app/services/morphosource/processing_activity_types_service.rb
+module Morphosource
+  # Provide select options for the series types field
+  class ProcessingActivityTypesService < Hyrax::QaSelectService
+    def initialize(_authority_name = nil)
+      super('processing_activity_types')
+    end
+
+    def include_current_value(value, _index, render_options, html_options)
+      unless value.blank? || active?(value)
+        html_options[:class] << ' force-select'
+        render_options += [[label(value) { value }, value]]
+      end
+      [render_options, html_options]
+    end
+
+  end
+end

--- a/app/views/hyrax/processing_events/_attribute_rows.html.erb
+++ b/app/views/hyrax/processing_events/_attribute_rows.html.erb
@@ -5,4 +5,5 @@
 <%= presenter.attribute_to_html(:date_created, render_as: :linked, search_field: 'date_created_tesim', html_dl: true) %>
 
 <!-- Processing Event Custom Fields -->
-<%= presenter.attribute_to_html(:software, render_as: :faceted, html_dl: true) %>
+<%= presenter.attribute_to_html(:software, search_field: 'software_sim', html_dl: true) %>
+<%= presenter.attribute_to_html(:processing_activity, html_dl: true) %>

--- a/app/views/records/edit_fields/_processing_activity.html.erb
+++ b/app/views/records/edit_fields/_processing_activity.html.erb
@@ -1,19 +1,22 @@
 <% # app/views/records/edit_fields/_processing_activity.html.erb %>
+<% processing_activity_types_service = Morphosource::ProcessingActivityTypesService.new %>
 <div id="processing_activities_wrapper" class="form-group multi_value optional processing_event_processing_activities" style="display:flex; flex-direction:column;">
 <label class="control-label multi_value optional" for="processing_event_processing_activity">Processing Activity</label>
 <ul class="listing">
+<% @curation_concern.processing_activity_type.map.with_index{|item,index| [item, @curation_concern.processing_activity_software[index], @curation_concern.processing_activity_description[index]] }.push([nil,nil,nil]).each do |processing_activity| %>
 <li class="field-wrapper">
-<% processing_activity_types_service = Morphosource::ProcessingActivityTypesService.new %>
 <%- # f.input :processing_activity_type, as: :select, collection: processing_activity_types_service.select_all_options, include_blank: true, item_helper: processing_activity_types_service.method(:include_current_value), input_html: { class: 'form-control' } -%>
-<div class="form-group select optional processing_event_processing_activity_type"><label class="control-label select optional" for="processing_event_processing_activity_type">Processing activity type</label><select class="form-control select optional form-control" name="processing_event[processing_activity_type][]" id="processing_event_processing_activity_type"><option value=""></option>
+<div class="form-group select optional processing_event_processing_activity_type"><label class="control-label select optional" for="processing_event_processing_activity_type">Processing activity type</label><select autocomplete="off" class="form-control select optional form-control" name="processing_event[processing_activity_type][]" id="processing_event_processing_activity_type"><option value=""></option>
     <% processing_activity_types_service.select_all_options.each do |processing_activity_type_option| %>
-      <option value="<%= processing_activity_type_option[0] %>"><%= processing_activity_type_option[1] %></option>
+      <option value="<%= processing_activity_type_option[0] %>" <%= (processing_activity_type_option[0] == processing_activity[0]) ? 'selected="selected"' : '' %>><%= processing_activity_type_option[1] %></option>
     <% end %>
 </select></div>
 <%- # f.input :processing_activity_software, as: :string, wrapper_html: { class: '' } -%>
-<div class="form-group string optional processing_event_processing_activity_software"><label class="control-label string optional" for="processing_event_processing_activity_software">Processing activity software</label><input class="form-control string optional" type="text" value="" name="processing_event[processing_activity_software][]" id="processing_event_processing_activity_software" /></div>
+<div class="form-group string optional processing_event_processing_activity_software"><label class="control-label string optional" for="processing_event_processing_activity_software">Processing activity software</label><input class="form-control string optional" type="text" value="<%= processing_activity[1].to_s %>" name="processing_event[processing_activity_software][]" id="processing_event_processing_activity_software" /></div>
 <%- # f.input :processing_activity_description, as: :text, input_html: { rows: '4' } -%>
-<div class="form-group text optional processing_event_processing_activity_description"><label class="control-label text optional" for="processing_event_processing_activity_description">Processing activity description</label><textarea class="form-control text optional" rows="4" name="processing_event[processing_activity_description][]" id="processing_event_processing_activity_description"></textarea></div>
+<div class="form-group text optional processing_event_processing_activity_description"><label class="control-label text optional" for="processing_event_processing_activity_description">Processing activity description</label><textarea class="form-control text optional" rows="4" name="processing_event[processing_activity_description][]" id="processing_event_processing_activity_description"><%= processing_activity[2].to_s %></textarea></div>
 </li>
+<br/>
+<% end %>
 </ul>
 </div>

--- a/app/views/records/edit_fields/_processing_activity.html.erb
+++ b/app/views/records/edit_fields/_processing_activity.html.erb
@@ -1,0 +1,19 @@
+<% # app/views/records/edit_fields/_processing_activity.html.erb %>
+<div id="processing_activities_wrapper" class="form-group multi_value optional processing_event_processing_activities" style="display:flex; flex-direction:column;">
+<label class="control-label multi_value optional" for="processing_event_processing_activity">Processing Activity</label>
+<ul class="listing">
+<li class="field-wrapper">
+<% processing_activity_types_service = Morphosource::ProcessingActivityTypesService.new %>
+<%- # f.input :processing_activity_type, as: :select, collection: processing_activity_types_service.select_all_options, include_blank: true, item_helper: processing_activity_types_service.method(:include_current_value), input_html: { class: 'form-control' } -%>
+<div class="form-group select optional processing_event_processing_activity_type"><label class="control-label select optional" for="processing_event_processing_activity_type">Processing activity type</label><select class="form-control select optional form-control" name="processing_event[processing_activity_type][]" id="processing_event_processing_activity_type"><option value=""></option>
+    <% processing_activity_types_service.select_all_options.each do |processing_activity_type_option| %>
+      <option value="<%= processing_activity_type_option[0] %>"><%= processing_activity_type_option[1] %></option>
+    <% end %>
+</select></div>
+<%- # f.input :processing_activity_software, as: :string, wrapper_html: { class: '' } -%>
+<div class="form-group string optional processing_event_processing_activity_software"><label class="control-label string optional" for="processing_event_processing_activity_software">Processing activity software</label><input class="form-control string optional" type="text" value="" name="processing_event[processing_activity_software][]" id="processing_event_processing_activity_software" /></div>
+<%- # f.input :processing_activity_description, as: :text, input_html: { rows: '4' } -%>
+<div class="form-group text optional processing_event_processing_activity_description"><label class="control-label text optional" for="processing_event_processing_activity_description">Processing activity description</label><textarea class="form-control text optional" rows="4" name="processing_event[processing_activity_description][]" id="processing_event_processing_activity_description"></textarea></div>
+</li>
+</ul>
+</div>

--- a/app/views/records/edit_fields/_processing_activity_description.html.erb
+++ b/app/views/records/edit_fields/_processing_activity_description.html.erb
@@ -1,0 +1,2 @@
+<% # app/views/records/edit_fields/_processing_activity_description.html.erb %>
+<% # see: app/views/records/edit_fields/_processing_activity.html.erb %>

--- a/app/views/records/edit_fields/_processing_activity_software.html.erb
+++ b/app/views/records/edit_fields/_processing_activity_software.html.erb
@@ -1,0 +1,2 @@
+<% # app/views/records/edit_fields/_processing_activity_software.html.erb %>
+<% # see: app/views/records/edit_fields/_processing_activity.html.erb %>

--- a/app/views/records/edit_fields/_processing_activity_type.html.erb
+++ b/app/views/records/edit_fields/_processing_activity_type.html.erb
@@ -1,0 +1,2 @@
+<% # app/views/records/edit_fields/_processing_activity_type.html.erb %>
+<% # see: app/views/records/edit_fields/_processing_activity.html.erb %>

--- a/config/authorities/processing_activity_types.yml
+++ b/config/authorities/processing_activity_types.yml
@@ -1,0 +1,19 @@
+terms:
+  - id: Raster-To-Mesh
+    term: Raster-To-Mesh
+  - id: Reconstruction
+    term: Reconstruction
+  - id: Simplification
+    term: Simplification
+  - id: Noise-Reduction / Smoothing
+    term: Noise-Reduction / Smoothing
+  - id: Alignment
+    term: Alignment
+  - id: Cropping
+    term: Cropping
+  - id: Histogram-Editing (raster only)
+    term: Histogram-Editing (raster only)
+  - id: Merge-n-datasets
+    term: Merge-n-datasets
+  - id: Other
+    term: Other

--- a/config/authorities/processing_activity_types.yml
+++ b/config/authorities/processing_activity_types.yml
@@ -1,19 +1,41 @@
 terms:
-  - id: Raster-To-Mesh
-    term: Raster-To-Mesh
+  - id: Reconstructed Tomography to Mesh
+    term: Reconstructed Tomography to Mesh
+  - id: Photos to Digital Elevation Model
+    term: Photos to Digital Elevation Model
+  - id: Photos to Sparse Point Cloud + Depth Map
+    term: Photos to Sparse Point Cloud + Depth Map
+  - id: Sparse Point Cloud + Depth Map to Dense Point Cloud
+    term: Sparse Point Cloud + Depth Map to Dense Point Cloud
+  - id: Photos to Sparse Mesh + Depth Map
+    term: Photos to Sparse Mesh + Depth Map
+  - id: Sparse Mesh + Depth Map to Mesh
+    term: Sparse Mesh + Depth Map to Mesh
+  - id: Photos to Dense Point Cloud
+    term: Photos to Dense Point Cloud
+  - id: Photos to Mesh
+    term: Photos to Mesh
+  - id: Mesh/Point Cloud Texturing
+    term: Mesh/Point Cloud Texturing
+  - id: Point Cloud to Mesh
+    term: Point Cloud to Mesh
+  - id: Mesh to Point Cloud
+    term: Mesh to Point Cloud
   - id: Reconstruction
     term: Reconstruction
+  - id: Smoothing/Noise Reduction
+    term: Smoothing/Noise Reduction
   - id: Simplification
     term: Simplification
-  - id: Noise-Reduction / Smoothing
-    term: Noise-Reduction / Smoothing
-  - id: Alignment
-    term: Alignment
-  - id: Cropping
-    term: Cropping
-  - id: Histogram-Editing (raster only)
-    term: Histogram-Editing (raster only)
-  - id: Merge-n-datasets
-    term: Merge-n-datasets
-  - id: Other
-    term: Other
+  - id: Histogram Editing
+    term: Histogram Editing
+  - id: Bit Depth Change
+    term: Bit Depth Change
+  - id: Image/Mesh Compression
+    term: Image/Mesh Compression
+  - id: Merge
+    term: Merge
+  - id: Crop
+    term: Crop
+  - id: Patch
+    term: Patch

--- a/spec/forms/hyrax/processing_event_form_spec.rb
+++ b/spec/forms/hyrax/processing_event_form_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Hyrax::ProcessingEventForm do
-  let(:all_metadata_fields) { [:creator, :date_created, :description, :software] }
+  let(:all_metadata_fields) { [:creator, :date_created, :description, :software, :processing_activity, :processing_activity_description, :processing_activity_software, :processing_activity_type] }
   let(:required_fields) { [] }
   let(:single_value_fields) { [:description, :date_created] }
 


### PR DESCRIPTION
The concatenated repeatable multi-field processing_activity needs to be created. This multi-field is a concatenated set of three individual metadata fields: processing_activity_type (drop-down), processing_activity_software (single line text entry), processing_activity_description (multi-line text entry).