### PR TITLE
Change after_create :add_id_to_title to use after_save instead

### DIFF
--- a/app/models/biological_specimen.rb
+++ b/app/models/biological_specimen.rb
@@ -1,7 +1,7 @@
 class BiologicalSpecimen < Morphosource::Works::Base
   include ::Hyrax::WorkBehavior
   validates_with Morphosource::ParentChildValidator
-  after_create :add_id_to_title
+  after_save :add_id_to_title
 
   self.indexer = BiologicalSpecimenIndexer
   # Change this to restrict which works can be added as a child.
@@ -49,8 +49,9 @@ class BiologicalSpecimen < Morphosource::Works::Base
 
   private
     def add_id_to_title
-      self.title.set("S#{self.id.to_s}: #{self.title.first.to_s}")
-      self.save!
+      unless self.title && self.id && self.title.first.to_s.start_with?("S#{self.id.to_s}: ")
+        self.title.set("S#{self.id.to_s}: #{self.title.first.to_s}")
+      end
     end
 
 end

--- a/app/models/cultural_heritage_object.rb
+++ b/app/models/cultural_heritage_object.rb
@@ -1,7 +1,7 @@
 class CulturalHeritageObject < Morphosource::Works::Base
   include ::Hyrax::WorkBehavior
   validates_with Morphosource::ParentChildValidator
-  after_create :add_id_to_title
+  after_save :add_id_to_title
 
   self.indexer = CulturalHeritageObjectIndexer
   # Change this to restrict which works can be added as a child.
@@ -19,7 +19,8 @@ class CulturalHeritageObject < Morphosource::Works::Base
 
   private
     def add_id_to_title
-      self.title.set("C#{self.id.to_s}: #{self.title.first.to_s}")
-      self.save!
+      unless self.title && self.id && self.title.first.to_s.start_with?("C#{self.id.to_s}: ")
+        self.title.set("C#{self.id.to_s}: #{self.title.first.to_s}")
+      end
     end
 end

--- a/app/models/imaging_event.rb
+++ b/app/models/imaging_event.rb
@@ -1,7 +1,7 @@
 class ImagingEvent < Morphosource::Works::Base
   include ::Hyrax::WorkBehavior
   validates_with Morphosource::ParentChildValidator
-  after_create :add_id_to_title
+  after_save :add_id_to_title
 
   self.work_requires_files = false
   self.indexer = ImagingEventIndexer
@@ -27,7 +27,8 @@ class ImagingEvent < Morphosource::Works::Base
 
   private
     def add_id_to_title
-      self.title.set("IE#{self.id.to_s}: #{self.title.first.to_s}")
-      self.save!
+      unless self.title && self.id && self.title.first.to_s.start_with?("IE#{self.id.to_s}: ")
+        self.title.set("IE#{self.id.to_s}: #{self.title.first.to_s}")
+      end
     end
 end

--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -1,7 +1,7 @@
 class Media < Morphosource::Works::Base
   include ::Hyrax::WorkBehavior
   validates_with Morphosource::ParentChildValidator
-  after_create :add_id_to_title
+  after_save :add_id_to_title
 
   self.work_requires_files = true
 
@@ -45,7 +45,8 @@ class Media < Morphosource::Works::Base
 
   private
     def add_id_to_title
-      self.title.set("M#{self.id.to_s}: #{self.title.first.to_s}")
-      self.save!
+      unless self.title && self.id && self.title.first.to_s.start_with?("M#{self.id.to_s}: ")
+        self.title.set("M#{self.id.to_s}: #{self.title.first.to_s}")
+      end
     end
 end

--- a/app/models/processing_event.rb
+++ b/app/models/processing_event.rb
@@ -1,7 +1,7 @@
 class ProcessingEvent < Morphosource::Works::Base
   include ::Hyrax::WorkBehavior
   validates_with Morphosource::ParentChildValidator
-  after_create :add_id_to_title
+  after_save :add_id_to_title
 
   self.indexer = ProcessingEventIndexer
   # Change this to restrict which works can be added as a child.
@@ -17,7 +17,8 @@ class ProcessingEvent < Morphosource::Works::Base
 
   private
     def add_id_to_title
-      self.title.set("PE#{self.id.to_s}: #{self.title.first.to_s}")
-      self.save!
+      unless self.title && self.id && self.title.first.to_s.start_with?("PE#{self.id.to_s}: ")
+        self.title.set("PE#{self.id.to_s}: #{self.title.first.to_s}")
+      end
     end
 end


### PR DESCRIPTION
Related to e.g. [MR-448](https://github.com/MorphoSource/MorphoSource_SF/pull/128), this switches title generation to use `after_save` instead of `after_create` so the title prefix doesn't get lost on updates.