### PR TITLE
MR-494: fix missing translations for labels

### DIFF
--- a/app/presenters/hyrax/biological_specimen_presenter.rb
+++ b/app/presenters/hyrax/biological_specimen_presenter.rb
@@ -11,10 +11,10 @@ module Hyrax
     def canonical_taxonomy_label
       if canonical_taxonomy_object.present?
         if canonical_taxonomy_object.trusted == ["Yes"]
-          return Morphosource::TAXONOMY_LABELS['trusted_canonical']
+          return I18n.t('morphosource.taxonomy.labels.trusted_canonical')
         end
       end
-      Morphosource::TAXONOMY_LABELS['canonical']
+      I18n.t('morphosource.taxonomy.labels.canonical')
     end
 
     def canonical_taxonomy_presenter

--- a/app/renderers/hyrax/renderers/related_taxonomies_renderer.rb
+++ b/app/renderers/hyrax/renderers/related_taxonomies_renderer.rb
@@ -27,10 +27,10 @@ module Hyrax
 
         def create_links(category)
           taxonomies = self.send(category)
-          labels = {:canonical_taxonomy => Morphosource::TAXONOMY_LABELS['canonical'],
-                    :trusted_canonical => Morphosource::TAXONOMY_LABELS['trusted_canonical'],
-                    :trusted_taxonomies => Morphosource::TAXONOMY_LABELS['trusted'],
-                    :user_taxonomies => Morphosource::TAXONOMY_LABELS['user']}
+          labels = {:canonical_taxonomy => I18n.t('morphosource.taxonomy.labels.canonical'),
+                    :trusted_canonical => I18n.t('morphosource.taxonomy.labels.trusted_canonical'),
+                    :trusted_taxonomies => I18n.t('morphosource.taxonomy.labels.trusted'),
+                    :user_taxonomies => I18n.t('morphosource.taxonomy.labels.user')}
 
           if taxonomies.present?
             taxonomies.each do |taxonomy|

--- a/app/renderers/hyrax/renderers/showcase_taxonomy_renderer.rb
+++ b/app/renderers/hyrax/renderers/showcase_taxonomy_renderer.rb
@@ -47,7 +47,7 @@ module Hyrax
       end
 
       def contributing_user(taxonomy)
-        return '' unless options[:label] == Morphosource::TAXONOMY_LABELS['user']
+        return '' unless options[:label] == I18n.t('morphosource.taxonomy.labels.user')
         contributing_user_link(taxonomy)
       end
 

--- a/app/views/hyrax/biological_specimens/_attribute_rows.html.erb
+++ b/app/views/hyrax/biological_specimens/_attribute_rows.html.erb
@@ -30,8 +30,8 @@
 
 
 <% institutional_taxonomy = presenter.attribute_to_html(:canonical_taxonomy_object, label: presenter.canonical_taxonomy_label, render_as: :showcase_taxonomy, include_empty: false, html_dl: true, locale: locale) %>
-<% trusted_taxonomies = presenter.attribute_to_html(:trusted_taxonomies, label: Morphosource::TAXONOMY_LABELS['trusted'], render_as: :showcase_taxonomy, include_empty: false, html_dl: true, locale: locale) %>
-<% user_taxonomies = presenter.attribute_to_html(:user_taxonomies, label: Morphosource::TAXONOMY_LABELS['user'], render_as: :showcase_taxonomy, include_empty: false, html_dl: true, locale: locale) %>
+<% trusted_taxonomies = presenter.attribute_to_html(:trusted_taxonomies, label: I18n.t('morphosource.taxonomy.labels.trusted'), render_as: :showcase_taxonomy, include_empty: false, html_dl: true, locale: locale) %>
+<% user_taxonomies = presenter.attribute_to_html(:user_taxonomies, label: I18n.t('morphosource.taxonomy.labels.user'), render_as: :showcase_taxonomy, include_empty: false, html_dl: true, locale: locale) %>
 
 <% unless institutional_taxonomy.blank? && trusted_taxonomies.blank? && user_taxonomies.blank? %>
   <h4>Taxonomies</h4>

--- a/app/views/hyrax/biological_specimens/_showcase_taxonomy.html.erb
+++ b/app/views/hyrax/biological_specimens/_showcase_taxonomy.html.erb
@@ -1,6 +1,6 @@
 <h2>BIOLOGICAL SPECIMEN TAXONOMY </h2>
 <div class="panel-group" id="taxonomy-accordion-group">
     <%= presenter.attribute_to_html(:canonical_taxonomy_object, render_as: :showcase_taxonomy, include_empty: false, html_dl: false, data_parent: "taxonomy-accordion-group", label: presenter.canonical_taxonomy_label, is_collapsed: true) %>
-    <%= presenter.attribute_to_html(:trusted_taxonomies, label: Morphosource::TAXONOMY_LABELS['trusted'], render_as: :showcase_taxonomy, include_empty: false, html_dl: false, data_parent: "taxonomy-accordion-group", is_collapsed: true) %>
-    <%= presenter.attribute_to_html(:user_taxonomies, label: Morphosource::TAXONOMY_LABELS['user'], render_as: :showcase_taxonomy, include_empty: false, html_dl: false, data_parent: "taxonomy-accordion-group", is_collapsed: true) %>
+    <%= presenter.attribute_to_html(:trusted_taxonomies, label: I18n.t('morphosource.taxonomy.labels.trusted'), render_as: :showcase_taxonomy, include_empty: false, html_dl: false, data_parent: "taxonomy-accordion-group", is_collapsed: true) %>
+    <%= presenter.attribute_to_html(:user_taxonomies, label: I18n.t('morphosource.taxonomy.labels.user'), render_as: :showcase_taxonomy, include_empty: false, html_dl: false, data_parent: "taxonomy-accordion-group", is_collapsed: true) %>
 </div>

--- a/lib/morphosource/configurable.rb
+++ b/lib/morphosource/configurable.rb
@@ -48,14 +48,6 @@ module Morphosource
         'Other' => {extensions: other_formats, label: I18n.t('morphosource.media.format_labels.other')}
       }
 
-      # taxonomy labels
-      TAXONOMY_LABELS = {
-        'canonical' => I18n.t('morphosource.taxonomy.labels.canonical'),
-        'trusted_canonical' => I18n.t('morphosource.taxonomy.labels.trusted_canonical'),
-        'trusted' => I18n.t('morphosource.taxonomy.labels.trusted'),
-        'user' => I18n.t('morphosource.taxonomy.labels.user')
-      }
     end
-
   end
 end

--- a/spec/renderers/hyrax/renderers/related_taxonomies_renderer_spec.rb
+++ b/spec/renderers/hyrax/renderers/related_taxonomies_renderer_spec.rb
@@ -15,15 +15,6 @@ RSpec.describe Hyrax::Renderers::RelatedTaxonomiesRenderer do
   let(:taxonomy_methods)  {[:canonical_taxonomy_object, :trusted_taxonomies, :user_taxonomies]}
   let(:subject)           { Nokogiri::HTML(renderer.render) }
 
-  before do
-    stub_const("Morphosource::TAXONOMY_LABELS", {
-      'canonical' => I18n.t('morphosource.taxonomy.labels.canonical'),
-      'trusted_canonical' => I18n.t('morphosource.taxonomy.labels.trusted_canonical'),
-      'trusted' => I18n.t('morphosource.taxonomy.labels.trusted'),
-      'user' => I18n.t('morphosource.taxonomy.labels.user')
-    })
-  end
-
   it 'delegates taxonomy methods to @specimen' do
     taxonomy_methods.each do |method|
       expect(@specimen).to receive(method)

--- a/spec/renderers/hyrax/renderers/showcase_taxonomy_renderer_spec.rb
+++ b/spec/renderers/hyrax/renderers/showcase_taxonomy_renderer_spec.rb
@@ -52,13 +52,12 @@ RSpec.describe Hyrax::Renderers::ShowcaseTaxonomyRenderer do
 
     before do
       allow_any_instance_of(described_class).to receive(:create_block).and_return(block)
-      I18n.t("morphosource.taxonomy.labels")
     end
 
     context 'all ranks are filled out' do
       let(:field)                      { :canonical_taxonomy_object }
       let(:canonical_taxonomy_object)  { Taxonomy.new(full_attrs) }
-      let(:label)                      { Morphosource::TAXONOMY_LABELS['canonical']}
+      let(:label)                      { I18n.t('morphosource.taxonomy.labels.canonical')}
       let(:renderer)                   { described_class.new(field, [canonical_taxonomy_object], data_parent: "taxonomy-accordion-group", label: label, is_collapsed: true) }
 
       let(:content) do
@@ -151,7 +150,7 @@ RSpec.describe Hyrax::Renderers::ShowcaseTaxonomyRenderer do
       let(:field)               { :trusted_taxonomies }
       let(:taxonomy1)           { Taxonomy.new(some_attrs) }
       let(:trusted_taxonomies)  { [ taxonomy1 ] }
-      let(:label)               { Morphosource::TAXONOMY_LABELS['trusted'] }
+      let(:label)               { I18n.t('morphosource.taxonomy.labels.trusted') }
       let(:renderer)            { described_class.new(field, trusted_taxonomies, data_parent: "taxonomy-accordion-group", label: label, is_collapsed: true) }
 
       let(:content) do
@@ -244,11 +243,11 @@ RSpec.describe Hyrax::Renderers::ShowcaseTaxonomyRenderer do
     context 'canonical_taxonomy' do
       let(:field)                      { :canonical_taxonomy_object }
       let(:canonical_taxonomy_object)  { Taxonomy.new(full_attrs) }
-      let(:label)                      { Morphosource::TAXONOMY_LABELS['canonical']}
+      let(:label)                      { I18n.t('morphosource.taxonomy.labels.canonical')}
       let(:renderer)                   { described_class.new(field, [canonical_taxonomy_object], data_parent: "taxonomy-accordion-group", label: label, is_collapsed: true) }
 
       it 'displays the label for trusted taxonomies' do
-        expect(renderer.render).to include Morphosource::TAXONOMY_LABELS['canonical']
+        expect(renderer.render).to include I18n.t('morphosource.taxonomy.labels.canonical')
       end
     end
 
@@ -256,11 +255,11 @@ RSpec.describe Hyrax::Renderers::ShowcaseTaxonomyRenderer do
       let(:field)               { :trusted_taxonomies }
       let(:taxonomy1)           { Taxonomy.new(some_attrs) }
       let(:trusted_taxonomies)  { [ taxonomy1 ] }
-      let(:label)               { Morphosource::TAXONOMY_LABELS['trusted'] }
+      let(:label)               { I18n.t('morphosource.taxonomy.labels.trusted') }
       let(:renderer)            { described_class.new(field, trusted_taxonomies, data_parent: "taxonomy-accordion-group", label: label, is_collapsed: true) }
 
       it 'displays the label for trusted taxonomies' do
-        expect(renderer.render).to include Morphosource::TAXONOMY_LABELS['trusted']
+        expect(renderer.render).to include I18n.t('morphosource.taxonomy.labels.trusted')
       end
     end
 
@@ -271,7 +270,7 @@ RSpec.describe Hyrax::Renderers::ShowcaseTaxonomyRenderer do
       let(:user_taxonomies)     { [ taxonomy1, taxonomy2 ] }
       let(:user1)               { User.new(id: 1, email: "example@email.com", display_name: "T. Ruxpin") }
       let(:user2)               { User.new(id: 2, email: "test@email.com", display_name: nil) }
-      let(:renderer)            { described_class.new(field, user_taxonomies, data_parent: "taxonomy-accordion-group", label: Morphosource::TAXONOMY_LABELS['user'], is_collapsed: true) }
+      let(:renderer)            { described_class.new(field, user_taxonomies, data_parent: "taxonomy-accordion-group", label: I18n.t('morphosource.taxonomy.labels.user'), is_collapsed: true) }
       let(:markup)              { '' << renderer.render }
 
       before do
@@ -280,7 +279,7 @@ RSpec.describe Hyrax::Renderers::ShowcaseTaxonomyRenderer do
       end
 
       it 'uses the user-supplied label' do
-        expect(markup).to include Morphosource::TAXONOMY_LABELS['user']
+        expect(markup).to include I18n.t('morphosource.taxonomy.labels.user')
       end
 
       it 'displays the display name of the taxonomy depositor' do


### PR DESCRIPTION
the labels constant in the configurable file seemed to be loading before the translation files, so the labels often say 'translation unavailable' instead of the real label. This change calls the translation directly. 