### PR TITLE
MR-503: Limit which file sets are included in a media work's manifest

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,8 @@ gem 'riiif', '~> 1.1'
 gem 'pul_uv_rails', :git => 'https://github.com/MorphoSource/pul_uv_rails.git', :branch => 'aleph'
 
 # pull iiif_manifest fork that can handle 3D manifests
-gem 'iiif_manifest', :git => 'https://github.com/JuliaWinchester/iiif_manifest.git'
+gem 'iiif_manifest', :git => 'https://github.com/MorphoSource/iiif_manifest.git', :branch => 'morphosource'
+
 
 gem 'hyrax', '2.4.1'
 gem 'hydra-role-management'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GIT
-  remote: https://github.com/JuliaWinchester/iiif_manifest.git
-  revision: edb9f53d5c11ab2e7c2f714f1e7db3e1dafd76de
+  remote: https://github.com/MorphoSource/iiif_manifest.git
+  revision: 6cfbe8b21eaf6f9f2a32c021b28864a6e8fde46b
+  branch: morphosource
   specs:
     iiif_manifest (0.5.0)
       activesupport (>= 4)

--- a/lib/morphosource/works/mime_types.rb
+++ b/lib/morphosource/works/mime_types.rb
@@ -1,22 +1,26 @@
 module Morphosource
-	module Works
-		module MimeTypes
-			extend ActiveSupport::Concern
-			include Hydra::Works::MimeTypes
+  module Works
+    module MimeTypes
+      extend ActiveSupport::Concern
+      include Hydra::Works::MimeTypes
 
-			def mesh?
-				self.class.mesh_mime_types.include? mime_type
-			end
+      def mesh?
+        self.class.mesh_mime_types.include? mime_type
+      end
 
-			module ClassMethods
-				def mesh_mime_types
-					['application/ply', 'application/stl', 'text/prs.wavefront-obj', 'model/gltf+json', 'model/vrml', 'model/x3d+xml']
-				end
+      def archive?
+        self.class.archive_mime_types.include? mime_type
+      end
 
-				def archive_mime_types
-					['application/zip']
-				end
-			end
-		end
-	end
+      module ClassMethods
+        def mesh_mime_types
+          ['application/ply', 'application/stl', 'text/prs.wavefront-obj', 'model/gltf+json', 'model/vrml', 'model/x3d+xml']
+        end
+
+        def archive_mime_types
+          ['application/zip']
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
- limits file sets to direct children (will not show file sets belonging to child media works)
- limits number of file sets by media type:
      - Image/Video: all file sets
      - Mesh: one file set
      - Other/Photogrammetry: no file sets
      - CT/MRI - coming soon 
