### PR TITLE
Add "cache: bundler" to Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 # Based on https://github.com/duke-libraries/rdr/blob/develop/.travis.yml
 
 language: ruby
+cache: bundler
 rvm:
   - 2.4.2
 services:


### PR DESCRIPTION
Running `bundle install` currently takes about 4 minutes of each Travis build. Caching this should hopefully speed things up.