### PR TITLE
MR-553: Separate new/old request tabs for the request manager page

### DIFF
--- a/app/controllers/morphosource/my/cart_items_controller.rb
+++ b/app/controllers/morphosource/my/cart_items_controller.rb
@@ -11,18 +11,25 @@ module Morphosource
 
       # Used by Add to Cart button on Work show page
       def create
-        unless work_already_in_cart?(params[:work_id])
-          @item = CartItem.new({:media_cart_id => params[:media_cart_id], :work_id => params[:work_id], :restricted => file_restricted?(params[:file_accessibility])})
-          if @item.save!
-            flash[:notice] = 'Item Added to Cart'
-          else
-            flash[:alert] = 'Item Add Unsuccessful'
+        work = @curation_concern
+        unless work_already_in_cart?(work.id)
+          item = create_item(params,work)
+          if item.restricted? && user_is_approver?(item)
+            unrestrict(item)
           end
+          flash[:notice] = 'Item Added to Cart'
         else
           flash[:alert] = 'Item Already in Cart'
         end
-        after_create_response(@curation_concern)
+        after_create_response(work)
       end
+
+      private
+
+        def create_item(params,work)
+          CartItem.create({:media_cart_id => params[:media_cart_id], :work_id => work.id, :restricted => work.restricted?})
+        end
+
     end
   end
 end

--- a/app/controllers/morphosource/my/media_carts_controller.rb
+++ b/app/controllers/morphosource/my/media_carts_controller.rb
@@ -11,21 +11,31 @@ module Morphosource
       end
 
       def download
-        if (params[:batch_document_ids] || params[:item_id])
-          item_ids = params[:batch_document_ids] || [params[:item_id]]
-          items = get_items_by_id(item_ids) & unrestricted_items
-        else
-          items = unrestricted_items
-        end
-        work_ids = get_work_ids_by_items(items)
-        mark_as('downloaded',items)
-        redirect_to main_app.zip_hyrax_media_index_path(ids: work_ids)
+        get_downloadable_items
+        mark_as('downloaded')
+        get_work_ids_by_items
+        redirect_to main_app.zip_hyrax_media_index_path(ids: @work_ids)
       end
 
       def destroy
-        items = get_items_by_id( params[:item_id] || params[:batch_document_ids] || item_ids_in_cart)
-        count = items.count.dup
-        items.each do |item|
+        get_items_by_id(id_params || item_ids_in_cart)
+        flash[:notice] = destroy_flash
+        remove_from_cart
+        redirect_back(fallback_location: my_cart_path)
+      end
+
+      private
+
+      def get_downloadable_items
+        @items = id_params ? get_items_by_id(id_params) & unrestricted_items : unrestricted_items
+      end
+
+      def destroy_flash
+        "#{item_count_text} Removed from Cart"
+      end
+
+      def remove_from_cart
+        @items.each do |item|
           if (item.date_downloaded? || item.date_requested?)
             item.in_cart = false
             item.save
@@ -33,8 +43,6 @@ module Morphosource
             item.destroy
           end
         end
-        flash[:notice] = "#{count_text(count)} Removed from Cart"
-        redirect_back(fallback_location: my_cart_path)
       end
 
     end

--- a/app/controllers/morphosource/my/requests_controller.rb
+++ b/app/controllers/morphosource/my/requests_controller.rb
@@ -4,32 +4,34 @@ module Morphosource
 
       include Morphosource::My::CartItemsBehavior
 
+      before_action :get_items_by_id, except: [:index]
+
       def index
         get_items('my_requests')
         render 'morphosource/my/requests/index'
       end
 
       def request_item
-        items = get_items_by_id( params[:item_id] || params[:batch_document_ids] )
-        requested_items = requested(items)
-        unrequested_items = unrequested(items)
-        mark_as('requested',unrequested_items)
-        re_request(requested_items)
-        flash[:notice] = count_text(items.count).concat(' Requested')
+        re_request(requested(@items))
+        mark_as('requested',unrequested(@items))
+        flash[:notice] = item_count_text.concat(' Requested')
         redirect_back(fallback_location: my_requests_path)
       end
 
       def request_again
-        item_ids = ( params[:item_id] || params[:batch_document_ids] )
-        items = get_items_by_id(item_ids)
-        re_request(items)
+        re_request(@items)
         redirect_back(fallback_location: my_requests_path)
       end
 
       def cancel_request
-        item = get_items_by_id(params[:item_id])
-        mark_as('canceled',item)
+        mark_as('canceled')
         flash[:notice] = "Request Canceled"
+        redirect_back(fallback_location: my_requests_path)
+      end
+
+      def move_to_cart
+        mark_as('in_cart',date: true)
+        flash[:notice] = "Item Moved to Cart"
         redirect_back(fallback_location: my_requests_path)
       end
 

--- a/app/helpers/morphosource/cart_item_helper.rb
+++ b/app/helpers/morphosource/cart_item_helper.rb
@@ -12,6 +12,8 @@ module Morphosource::CartItemHelper
       make_label("Expired","label label-warning","background-color: orange;")
     when 'Approved'
       make_label("Approved","label label-success",'')
+    when 'Cleared'
+      make_label("Cleared","label label-info",'')
     when 'Requested'
       make_label("Requested","label label-primary",'')
     else
@@ -23,6 +25,12 @@ module Morphosource::CartItemHelper
   # arguments: item, button text, button class, http method, style
   def item_action_button(item)
     case item.request_status
+    when 'Approved'
+      if !item.in_cart
+        make_button(item,"Add to Cart",:move_to_cart_path,"btn btn-success",:put,'')
+      else
+        content_tag(:button, 'Item in Cart', class: "btn btn-success", disabled: true)
+      end
     when 'Canceled'
       make_button(item,"Request Download",:request_item_path,"btn btn-info",:put,'')
     when 'Denied'
@@ -33,6 +41,8 @@ module Morphosource::CartItemHelper
       end
     when 'Expired'
       make_button(item,"Request Again",:request_again_path,"btn btn-primary",:get,'')
+    when 'Cleared'
+     make_button(item,"Request Download",:request_item_path,"btn btn-info",:put,'')
     when 'Requested'
       make_button(item,"Cancel Request",:cancel_request_path,"btn btn-danger",:put,"background-color: gray;")
     when 'Downloadable'
@@ -48,5 +58,10 @@ module Morphosource::CartItemHelper
 
   def make_button(item,text,path,button_class,method,style)
     link_to text, main_app.send(path, item_id: item.id), class: button_class, style: style, method: method
+  end
+
+  def date(item,attribute)
+    attribute = 'date_'.concat(attribute).to_sym
+    item.send(attribute)&.strftime("%Y-%m-%d")
   end
 end

--- a/app/models/cart_item.rb
+++ b/app/models/cart_item.rb
@@ -29,6 +29,8 @@ class CartItem < ApplicationRecord
       "Expired"
     elsif self.date_approved.present?
       "Approved"
+    elsif self.date_cleared.present?
+      "Cleared"
     elsif self.date_requested.present?
       "Requested"
     elsif self.restricted?
@@ -55,8 +57,12 @@ class CartItem < ApplicationRecord
     self.date_expired < Time.now
   end
 
+  def approved?
+    self.request_status == 'Approved'
+  end
+
   # for now, approver = depositor
-   def set_approver
+  def set_approver
     self.approver = work.depositor
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -80,17 +80,41 @@ class User < ApplicationRecord
     my_requests.map{ |item| item.work_id }
   end
 
-  # items requested from user (items where user is data owner)
+  # items requested from user (items where user is data manager)
   def requested_items
-    CartItem.where.not(date_requested: nil).or(CartItem.where.not(date_cleared: nil))
+    CartItem.where(approver: self.email).where.not(date_requested: nil).or(CartItem.where(approver: self.email).where.not(date_cleared: nil))
+  end
+
+   def previously_requested_items
+    requested_items.select{|item| (item.date_approved || item.date_denied || item.date_canceled || item.date_cleared)}
+  end
+
+   def newly_requested_items
+    requested_items - previously_requested_items
   end
 
   def requested_item_ids
     requested_items.map{|item| item.id}
   end
 
+  def previously_requested_item_ids
+    previously_requested_items.map{|item| item.id}
+  end
+
+  def newly_requested_item_ids
+    newly_requested_items.map{|item| item.id}
+  end
+
   def requested_items_work_ids
     requested_items.map{ |item| item.work_id }
+  end
+
+  def previously_requested_items_work_ids
+    previously_requested_items.map{ |item| item.work_id }
+  end
+
+  def newly_requested_items_work_ids
+    newly_requested_items.map{ |item| item.work_id }
   end
 
   def downloaded_items

--- a/app/views/hyrax/media/_showcase_show_actions.html.erb
+++ b/app/views/hyrax/media/_showcase_show_actions.html.erb
@@ -17,9 +17,9 @@
         <% if @presenter.works_in_cart.include? params[:id] %>
           <%= link_to "Item in Cart", main_app.my_cart_path, class: 'btn btn-default' %>
         <% elsif (@presenter&.fileset_accessibility&.first == 'open' || @presenter&.fileset_accessibility&.first == 'restricted_download') %>
-          <%= link_to "Add to Cart", main_app.add_to_cart_path(:work_id => @presenter.id, :media_cart_id => current_user.media_cart.id, :work_type => @presenter.model_name.name, :file_accessibility => @presenter.fileset_accessibility.first), class: 'btn btn-default', :method => :post %>
+          <%= link_to "Add to Cart", main_app.add_to_cart_path(:work_id => @presenter.id, :media_cart_id => current_user.media_cart.id, :work_type => "Media"), class: 'btn btn-default', :method => :post %>
         <% else %>
-          <%= link_to "Add to Cart", main_app.add_to_cart_path(:work_id => @presenter.id, :media_cart_id => current_user.media_cart.id, :work_type => @presenter.model_name.name, :file_accessibility => "open"), class: 'btn btn-default', :method => :post %>
+          <%= link_to "Add to Cart", main_app.add_to_cart_path(:work_id => @presenter.id, :media_cart_id => current_user.media_cart.id, :work_type => "Media"), class: 'btn btn-default', :method => :post %>
         <% end %>
       <% end %>
 

--- a/app/views/morphosource/batch_edits/_approve_selected.html.erb
+++ b/app/views/morphosource/batch_edits/_approve_selected.html.erb
@@ -1,3 +1,0 @@
-<%= form_tag(main_app.approve_download_path, method: :put, class: "button_to-inline", "data-behavior" => 'batch-select-all') do -%>
-  <%= submit_tag("Approve Selected", class: 'batch-all-button btn btn-primary submits-batches', id:'request-selected') %>
-<% end %>

--- a/app/views/morphosource/batch_edits/_download_selected.html.erb
+++ b/app/views/morphosource/batch_edits/_download_selected.html.erb
@@ -1,3 +1,3 @@
 <%= form_tag(main_app.download_items_path, method: :get, class: "button_to-inline", "data-behavior" => 'batch-select-all') do -%>
-  <%= submit_tag("Download Selected", class: 'batch-all-button btn btn-primary submits-batches', id: 'download-selected') %>
+  <%= submit_tag("Download Selected", class: 'batch-all-button btn btn-info submits-batches', id: 'download-selected') %>
 <% end %>

--- a/app/views/morphosource/batch_edits/_new_requests.html.erb
+++ b/app/views/morphosource/batch_edits/_new_requests.html.erb
@@ -1,0 +1,11 @@
+<div >
+  <button id= 'batch-approval-button' class='btn btn-success batch-all-button' data-toggle="modal" data-target="#batchApprovalModal">Approve Download</button>
+
+  <%= form_tag(main_app.clear_request_path, method: :put, class: "button_to-inline", "data-behavior" => 'batch-select-all') do -%>
+    <%= submit_tag("Clear Selected", class: 'batch-all-button btn btn-info submits-batches', id:'request-selected') %>
+  <% end %>
+
+  <%= form_tag(main_app.deny_download_path, method: :put, class: "button_to-inline", "data-behavior" => 'batch-select-all') do -%>
+    <%= submit_tag("Deny Selected", class: 'batch-all-button btn btn-danger submits-batches', id:'request-selected') %>
+  <% end %>
+</div>

--- a/app/views/morphosource/my/_cart_scripts.js.erb
+++ b/app/views/morphosource/my/_cart_scripts.js.erb
@@ -1,7 +1,6 @@
 function hideButtons() {
   let downloadable = $(".downloadable_items").length;
   let restricted = $(".restricted_items").length;
-
   let select_downloadable = $('#unrestricted_documents > table > thead > tr > th.check-all');
   let select_restricted = $('#documents > table > thead > tr > th.check-all');
 
@@ -39,7 +38,6 @@ function togglePageButtons() {
 
 function toggleDownloadableButtons() {
   let downloadable = $(".downloadable_items:checked").length;
-
   if ( downloadable > 0 ) {
     $('#delete-selected').prop('disabled', false);
     $('#download-selected').prop('disabled', false);
@@ -51,7 +49,6 @@ function toggleDownloadableButtons() {
 
 function toggleRestrictedButtons() {
   let restricted = $(".restricted_items:checked").length;
-
   if ( restricted > 0 ) {
     $('#request-selected').prop('disabled', false);
     $('#delete-selected-restricted').prop('disabled', false);
@@ -60,7 +57,6 @@ function toggleRestrictedButtons() {
     $('#delete-selected-restricted').prop('disabled', true);
   }
 }
-
 
 Blacklight.onLoad(function() {
   togglePageButtons();

--- a/app/views/morphosource/my/_request_manager_scripts.js.erb
+++ b/app/views/morphosource/my/_request_manager_scripts.js.erb
@@ -1,0 +1,45 @@
+function togglePageButtons() {
+  let items = $(".batch_document_selector:checked").length;
+  if ( items > 0 ) {
+    $('.batch-all-button').prop('disabled', false);
+  } else {
+    $('.batch-all-button').prop('disabled', true);
+  }
+}
+
+// submit item id for individual download approvals
+$('body').on('shown.bs.modal', '#editExpiration, #approvalModal', function (e) {
+  var item_id = $(e.relatedTarget).data('item-id');
+  $('#item_id_').val(item_id);
+});
+
+function createHiddenInputs(id) {
+  var form = $('#modal-form');
+  var input = document.createElement("input");
+  input.setAttribute('type','hidden');
+  input.setAttribute('name','batch_document_ids[]');
+  input.setAttribute('value',id);
+  form.append(input);
+}
+
+// submit all item ids for batch approvals
+$('body').on('shown.bs.modal', '#batchApprovalModal', function (e) {
+  var item_ids = [];
+  $.each($('.batch_document_selector:checked'), function(){
+    item_ids.push($(this).val());
+  });
+  item_ids.forEach(createHiddenInputs);
+});
+
+Blacklight.onLoad(function() {
+  togglePageButtons();
+  // toggle button on or off based on boxes being clicked
+  $(".batch_document_selector, #check_all").bind('click', function(e) {
+    togglePageButtons();
+  });
+  // remove item ids from form if modal cancel button is clicked
+  $("#cancel-batch-approval").bind('click', function(e) {
+    var form = $('#modal-form');
+    form.find('input[name="batch_document_ids[]"]').remove();
+  });
+});

--- a/app/views/morphosource/my/cart/_list_works.html.erb
+++ b/app/views/morphosource/my/cart/_list_works.html.erb
@@ -22,6 +22,9 @@
             <% if item.restricted == true %>
               <span class="label" style="background: teal;">Download Approved</span>
             <% end %>
+            <% if current_user.email == item.approver %>
+              <span class="label" style="background: blue;">Your Media</span>
+            <% end %>
           <% end %>
           <br />
         </div>
@@ -29,7 +32,7 @@
     </div>
   </td>
   <td class="date"><%= item.created_at.strftime("%Y-%m-%d") %></td>
-  <td><%=item.date_approved&.strftime("%Y-%m-%d") %></td>
-  <td><%=item.date_expired&.strftime("%Y-%m-%d") %></td>
+  <td><%= date(item,'approved') %></td>
+  <td><%= date(item,'expired') %></td>
   <td><%= link_to "Download Item", main_app.download_items_path(item_id: item.id), class: "btn btn-info", method: :get %></td>
 </tr>

--- a/app/views/morphosource/my/downloads/_list_works.html.erb
+++ b/app/views/morphosource/my/downloads/_list_works.html.erb
@@ -31,10 +31,12 @@
   <td>
     <% if document.fileset_accessibility&.first == "restricted_download" %>
       <span class="label label-danger">Restricted</span>
+    <% elsif document.fileset_accessibility&.first == "open" %>
+      <span class="label label-success">Open</span>
     <% end %>
   </td>
 
-  <td class="date"><%= item.date_downloaded.strftime("%Y-%m-%d") %></td>
+  <td class="date"><%= date(item,'downloaded') %></td>
 
 
 </tr>

--- a/app/views/morphosource/my/request_manager/_approval_modal.html.erb
+++ b/app/views/morphosource/my/request_manager/_approval_modal.html.erb
@@ -1,0 +1,21 @@
+<div class="modal fade" id="approvalModal" tabindex="-1" role="dialog" aria-labelledby="approvalModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
+        <h4 class="modal-title">Set Expiration</h4>
+      </div>
+      <div class="modal-body">
+        <%= form_tag main_app.approve_download_path, method: :put, :class => "form-horizontal" do %>
+              <%= label_tag 'expiration date', 'New Expiration Date', :class => 'control-label' %>
+              <%= date_field :expiration_date, params[:date], :class => "form-control" %>
+              <%= hidden_field :item_id, params[:id] %>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-danger" data-dismiss="modal">Cancel</button>
+           <%= submit_tag "Submit", name: nil, class: "btn btn-success" %>
+        <% end %>
+      </div>
+    </div><!-- /.modal-content -->
+  </div><!-- /.modal-dialog -->
+</div><!-- /.modal -->

--- a/app/views/morphosource/my/request_manager/_batch_actions.html.erb
+++ b/app/views/morphosource/my/request_manager/_batch_actions.html.erb
@@ -1,6 +1,8 @@
 <div>
   <div>
-    <% session[:batch_edit_state] = "on" %>
-    <%= render 'morphosource/batch_edits/approve_selected' %>
+    <% if @tab == 'new' %>
+      <% session[:batch_edit_state] = "on" %>
+      <%= render 'morphosource/batch_edits/new_requests' %>
+    <% end %>
   </div>
 </div>

--- a/app/views/morphosource/my/request_manager/_batch_approval_modal.html.erb
+++ b/app/views/morphosource/my/request_manager/_batch_approval_modal.html.erb
@@ -1,0 +1,20 @@
+<div class="modal fade" id="batchApprovalModal" tabindex="-1" role="dialog" aria-labelledby="approvalModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
+        <h4 class="modal-title">Set Download Expiration Date</h4>
+      </div>
+      <div class="modal-body">
+        <%= form_tag(main_app.approve_download_path, method: :put, id: 'modal-form', :class => "form-horizontal", "data-behavior" => 'batch-select-all') do %>
+              <%= label_tag 'expiration date', 'Expiration Date', :class => 'control-label' %>
+              <%= date_field :expiration_date, params[:date], :class => "form-control" %>
+      </div>
+      <div class="modal-footer">
+        <button type="button" id="cancel-batch-approval" class="btn btn-danger" data-dismiss="modal">Cancel</button>
+           <%= submit_tag "Submit", name: nil, class: 'batch-all-button btn btn-success submits-batches' %>
+        <% end %>
+      </div>
+    </div><!-- /.modal-content -->
+  </div><!-- /.modal-dialog -->
+</div><!-- /.modal -->

--- a/app/views/morphosource/my/request_manager/_default_group.html.erb
+++ b/app/views/morphosource/my/request_manager/_default_group.html.erb
@@ -2,20 +2,34 @@
   <caption class="sr-only"><%= t("hyrax.dashboard.my.sr.listing") %> <%= application_name %></caption>
   <thead>
   <tr>
-    <th class="check-all"><label for="check_all" class="sr-only"><%= t("hyrax.dashboard.my.sr.check_all_label") %></label><%= render_check_all %></th>
+    <% if @tab == 'new' %>
+      <th class="check-all"><label for="check_all" class="sr-only"><%= t("hyrax.dashboard.my.sr.check_all_label") %></label><%= render_check_all %></th>
+    <% end %>
     <th><%= t("hyrax.dashboard.my.heading.title") %></th>
-    <th>Request Status</th>
+    <% if @tab == 'previous' %>
+      <th>Request Status</th>
+    <% end %>
     <th>Requester</th>
     <th>Affiliation</th>
-    <th>Requested</th>
-    <th>Approved</th>
-    <th>Denied</th>
-    <th>Canceled</th>
-    <th>Expiration</th>
-    <th>Cleared</th>
-    <th>Approve</th>
-    <th>Clear</th>
-    <th>Deny</th>
+
+    <% if @tab == 'new' %>
+      <th>Requested</th>
+      <th>Approve</th>
+      <th>Clear</th>
+      <th>Deny</th>
+    <% end %>
+
+    <% if @tab == 'previous' %>
+      <th>Requested</th>
+      <th>Approved</th>
+      <th>Denied</th>
+      <th>Canceled</th>
+      <th>Expiration</th>
+      <th>Cleared</th>
+      <th>Downloaded</th>
+      <th></th>
+    <% end %>
+
   </tr>
   </thead>
   <tbody>
@@ -25,3 +39,9 @@
     <% end %>
   </tbody>
 </table>
+<% if @tab == 'previous' %>
+  <%= render 'morphosource/my/request_manager/expiration_modal' %>
+<% else %>
+  <%= render 'morphosource/my/request_manager/approval_modal' %>
+  <%= render 'morphosource/my/request_manager/batch_approval_modal' %>
+<% end %>

--- a/app/views/morphosource/my/request_manager/_expiration_modal.html.erb
+++ b/app/views/morphosource/my/request_manager/_expiration_modal.html.erb
@@ -1,0 +1,21 @@
+<div class="modal fade" id="editExpiration" tabindex="-1" role="dialog" aria-labelledby="approvalModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
+        <h4 class="modal-title">Edit Request</h4>
+      </div>
+      <div class="modal-body">
+        <%= form_tag main_app.edit_expiration_path, method: :put, :class => "form-horizontal" do %>
+              <%= label_tag 'expiration date', 'New Expiration Date', :class => 'control-label' %>
+              <%= date_field :expiration_date, params[:date], :class => "form-control" %>
+              <%= hidden_field :item_id, params[:id] %>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-danger" data-dismiss="modal">Cancel</button>
+           <%= submit_tag "Submit", name: nil, class: "btn btn-success" %>
+        <% end %>
+      </div>
+    </div><!-- /.modal-content -->
+  </div><!-- /.modal-dialog -->
+</div><!-- /.modal -->

--- a/app/views/morphosource/my/request_manager/_list_works.html.erb
+++ b/app/views/morphosource/my/request_manager/_list_works.html.erb
@@ -1,9 +1,10 @@
 <tr id="document_<%= document.id %>">
-
-  <td>
-    <label for="batch_document_<%= document.id %>" class="sr-only"><%= t("hyrax.dashboard.my.sr.batch_checkbox") %></label>
-    <%= render 'morphosource/batch_select/add_button', item: item %>&nbsp;
-  </td>
+  <% if @tab == 'new' %>
+    <td>
+      <label for="batch_document_<%= document.id %>" class="sr-only"><%= t("hyrax.dashboard.my.sr.batch_checkbox") %></label>
+      <%= render 'morphosource/batch_select/add_button', item: item %>&nbsp;
+    </td>
+  <% end %>
 
   <td>
     <div class='media'>
@@ -24,21 +25,31 @@
       </div>
     </div>
   </td>
-  <td><%= item_status_label(item) %></td>
+  <% if @tab == 'previous' %>
+    <td><%= item_status_label(item) %></td>
+  <% end %>
   <td><%= item.requester_email %></td>
   <td><%= item.requester_affiliation %></td>
-  <td><%= item.date_requested.strftime("%Y-%m-%d") %></td>
-  <td><%= item.date_approved&.strftime("%Y-%m-%d") %></td>
-  <td><%= item.date_denied&.strftime("%Y-%m-%d") %></td>
-  <td><%= item.date_canceled&.strftime("%Y-%m-%d") %></td>
-  <td><%= item.date_expired&.strftime("%Y-%m-%d") %></td>
-  <td><%= item.date_cleared&.strftime("%Y-%m-%d") %></td>
-  <td><%= link_to "Approve Download", main_app.approve_download_path(:item_id => item.id), class: 'btn btn-success', :method => :put %></td>
-  <td><%= link_to "Clear Request", main_app.clear_request_path(:item_id => item.id), class: 'btn btn-info', :method => :put %></td>
-  <td><%= link_to "Deny Download", main_app.deny_download_path(:item_id => item.id), class: 'btn btn-danger', :method => :put %></td>
-</tr>
 
+  <% if @tab == 'new' %>
+    <td><%= date(item,'requested') %></td>
+    <td><button class='btn btn-success' data-toggle="modal" data-target="#approvalModal" data-item-id= <%= item.id %>>Approve Download</button></td>
+    <td><%= link_to "Clear Request", main_app.clear_request_path(:item_id => item.id), class: 'btn btn-info', :method => :put %></td>
+    <td><%= link_to "Deny Download", main_app.deny_download_path(:item_id => item.id), class: 'btn btn-danger', :method => :put %></td>
+  <% end %>
 
-
-
+  <% if @tab == 'previous' %>
+    <td><%= date(item,'requested') %></td>
+    <td><%= date(item,'approved') %></td>
+    <td><%= date(item,'denied') %></td>
+    <td><%= date(item,'canceled') %></td>
+    <td><%= date(item,'expired') %></td>
+    <td><%= date(item,'cleared') %></td>
+    <td><%= date(item,'downloaded') %></td>
+    <% if ( item.expired? || item.approved? ) %>
+      <td><button class='btn btn-primary' data-toggle="modal" data-target="#editExpiration" data-item-id= <%= item.id %>>Edit Expiration</button></td>
+    <% else %>
+      <td></td>
+    <% end %>
+  <% end %>
 </tr>

--- a/app/views/morphosource/my/request_manager/_tabs.html.erb
+++ b/app/views/morphosource/my/request_manager/_tabs.html.erb
@@ -1,0 +1,8 @@
+<ul class="nav nav-tabs" id="my_nav" role="navigation">
+  <li<%= ' class="active"'.html_safe if current_page?(main_app.request_manager_path) %>>
+    <%= link_to t("New Requests"), main_app.request_manager_path %>
+  </li>
+  <li<%= ' class="active"'.html_safe if current_page?(main_app.previous_requests_path) %>>
+    <%= link_to t("Previous Requests"), main_app.previous_requests_path %>
+  </li>
+</ul>

--- a/app/views/morphosource/my/request_manager/index.html.erb
+++ b/app/views/morphosource/my/request_manager/index.html.erb
@@ -1,11 +1,10 @@
-  <% provide :page_title, "Requests" %>
-
+<% provide :page_title, "Manage Requests" %>
 
 <nav class="breadcrumb" role="region" aria-label="Breadcrumb">
   <ol>
     <li><a href="/?locale=en">Home</a></li>
     <li><a href="/dashboard?locale=en">Dashboard</a></li>
-    <li class="active">Requests</li>
+    <li class="active">Manage Requests</li>
   </ol>
 </nav>
 
@@ -13,20 +12,29 @@
   <div class="col-xs-12 main-header">
     <h1>
       <span class="fa fa-tasks" aria-hidden="true"></span>
-      Requests ( <%= @item_count %> )
+      <% if @tab == 'new' %>
+        New Requests
+      <% else %>
+        Previous Requests
+      <% end %>
+      ( <%= @item_count %> )
     </h1>
   </div>
 </div>
 
 <script>
 //<![CDATA[
-  <%= render partial: 'morphosource/my/scripts', formats: [:js] %>
+  <%= render partial: 'morphosource/my/request_manager_scripts', formats: [:js] %>
 //]]>
 </script>
-
-<div class="panel-body">
-  <h2 class="sr-only">Works listing</h2>
-  <%= render 'morphosource/my/request_manager/batch_actions' %>
-  <%= render 'morphosource/my/request_manager/document_list' %>
-  <%= render 'morphosource/my/request_manager/results_pagination' %>
+<div class="panel panel-default tabs">
+  <%= render 'morphosource/my/request_manager/tabs' %>
+  <div class="panel-body">
+    <h2 class="sr-only">Works listing</h2>
+    <% if @tab == 'new' %>
+      <%= render 'morphosource/my/request_manager/batch_actions' %>
+    <% end %>
+    <%= render 'morphosource/my/request_manager/document_list' %>
+    <%= render 'morphosource/my/request_manager/results_pagination' %>
+  </div>
 </div>

--- a/app/views/morphosource/my/requests/_list_works.html.erb
+++ b/app/views/morphosource/my/requests/_list_works.html.erb
@@ -27,10 +27,10 @@
   <td><%= item_status_label(item) %></td>
   <td><%= item.approver %></td>
   <td><%= item.approving_user.affiliation %></td>
-  <td><%= item.date_requested&.strftime("%Y-%m-%d") %></td>
-  <td><%= item.date_approved&.strftime("%Y-%m-%d") %></td>
-  <td><%= item.date_denied&.strftime("%Y-%m-%d") %></td>
-  <td><%= item.date_canceled&.strftime("%Y-%m-%d") %></td>
-  <td><%= item.date_expired&.strftime("%Y-%m-%d") %></td>
+  <td><%= date(item,'requested') %></td>
+  <td><%= date(item,'approved') %></td>
+  <td><%= date(item,'denied') %></td>
+  <td><%= date(item,'canceled') %></td>
+  <td><%= date(item,'expired') %></td>
   <td><%= item_action_button(item) %></td>
 </tr>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -135,14 +135,16 @@ Rails.application.routes.draw do
       get 'dashboard/my/requests', action: :index, controller: :requests, as: 'my_requests'
       put 'request_item', action: :request_item, controller: :requests, as: 'request_item'
       get 'request_again', action: :request_again, controller: :requests, as: 'request_again'
-      put 'cancel_request', action: :cancel_request,
-      controller: :requests, as: 'cancel_request'
+      put 'cancel_request', action: :cancel_request, controller: :requests, as: 'cancel_request'
+      put 'move_to_cart', action: :move_to_cart, controller: :requests
 
       # request manager
       get 'dashboard/my/request_manager', action: :index, controller: :request_managers, as: 'request_manager'
+      get 'dashboard/my/previous_requests', action: :index, controller: :request_managers, as: 'previous_requests'
       put 'approve_download', action: :approve_download, controller: :request_managers, as: 'approve_download'
       put 'clear_request', action: :clear_request, controller: :request_managers, as: 'clear_request'
       put 'deny_download', action: :deny_download, controller: :request_managers, as: 'deny_download'
+      put 'edit_expiration', action: :edit_expiration, controller: :request_managers, as: 'edit_expiration'
     end
   end
 end

--- a/spec/controllers/morphosource/my/request_managers_controller_spec.rb
+++ b/spec/controllers/morphosource/my/request_managers_controller_spec.rb
@@ -17,26 +17,46 @@ RSpec.describe Morphosource::My::RequestManagersController, :type => :controller
 
   describe "GET #index" do
 
-    before do
-      get :index
+    context 'normal index stuff' do
+      before do
+        get :index
+      end
+
+      include_examples '#index'
+
     end
 
-    include_examples '#index'
-    include_examples '#get_items instance variables', 'request manager'
+    context 'user looks at new requests' do
+      before do
+        get :index
+      end
+
+      include_examples '#get_items instance variables', 'request manager'
+    end
+
+    context 'user looks at previous requests' do
+
+      before do
+        allow(subject).to receive(:previous_requests?).and_return(true)
+        get :index
+      end
+
+      include_examples '#get_items instance variables', 'previous requests'
+    end
 
   end
 
   describe "PUT #approve_download" do
     context 'the data manager approves one request' do
       before do
-        put :approve_download, params: { item_id: cartItem1.id }
+        put :approve_download, params: { item_id: cartItem1.id, expiration_date: [1.month.from_now] }
         cartItem1.reload
       end
       it "marks the item's date approved to today" do
         expect(cartItem1.date_approved.to_date).to eq(Date.today)
       end
-      it "marks the item's date expired to tomorrow" do
-        expect(cartItem1.date_expired.to_date).to eq(Date.tomorrow)
+      it "marks the item's date expired to one month from now" do
+        expect(cartItem1.date_expired.to_date).to eq(1.month.from_now.to_date)
       end
       it "creates a flash message with the number of items approved" do
         expect(response.flash[:notice]).to eq("1 Item Approved for Download")
@@ -47,16 +67,16 @@ RSpec.describe Morphosource::My::RequestManagersController, :type => :controller
     end
     context 'the data manager approves multiple requests' do
       before do
-        put :approve_download, params: { batch_document_ids: [cartItem1.id,cartItem5.id] }
+        put :approve_download, params: { batch_document_ids: [cartItem1.id,cartItem5.id], expiration_date: [1.month.from_now] }
         [cartItem1,cartItem5].each(&:reload)
       end
       it "marks the items' date approved to today" do
         expect(cartItem1.date_approved.to_date).to eq(Date.today)
         expect(cartItem5.date_approved.to_date).to eq(Date.today)
       end
-      it "marks the items' date expired to tomorrow" do
-        expect(cartItem1.date_expired.to_date).to eq(Date.tomorrow)
-        expect(cartItem5.date_expired.to_date).to eq(Date.tomorrow)
+      it "marks the items' date expired to one month from now" do
+        expect(cartItem1.date_expired.to_date).to eq(1.month.from_now.to_date)
+        expect(cartItem5.date_expired.to_date).to eq(1.month.from_now.to_date)
       end
       it "creates a flash message with the number of items approved" do
         expect(response.flash[:notice]).to eq("2 Items Approved for Download")
@@ -69,14 +89,14 @@ RSpec.describe Morphosource::My::RequestManagersController, :type => :controller
 
   describe 'PUT #clear_request' do
     before do
-      put :clear_request, params: { item_id: cartItem1.id }
-      cartItem1.reload
+      put :clear_request, params: { item_id: cartItem5.id }
+      cartItem5.reload
     end
     it "clears the item's date requested" do
-      expect(cartItem1.date_requested).to be(nil)
+      expect(cartItem5.date_requested).to be(nil)
     end
     it 'marks the date cleared as today' do
-      expect(cartItem1.date_cleared.to_date).to eq(Date.today)
+      expect(cartItem5.date_cleared.to_date).to eq(Date.today)
     end
     it 'creates a flash message' do
       expect(response.flash[:notice]).to eq("Request cleared for 1 Item")
@@ -88,17 +108,33 @@ RSpec.describe Morphosource::My::RequestManagersController, :type => :controller
 
   describe "PUT #deny_download" do
     before do
-      put :deny_download, params: { item_id: cartItem1.id }
-      cartItem1.reload
+      put :deny_download, params: { item_id: cartItem5.id }
+      cartItem5.reload
     end
     it "marks the item's date denied to today" do
-      expect(cartItem1.date_denied.to_date).to eq(Date.today)
+      expect(cartItem5.date_denied.to_date).to eq(Date.today)
     end
     it "creates a flash message" do
       expect(response.flash[:notice]).to eq("Download Denied")
     end
     it "redirects to the request manager page" do
       expect(response).to redirect_to(request_manager_path)
+    end
+  end
+
+  describe 'PUT #edit_expiration' do
+    before do
+      put :edit_expiration, params: { item_id: cartItem1.id, expiration_date: [Date.yesterday] }
+    end
+    it "marks the item's expiration date as yesterday" do
+      cartItem1.reload
+      expect(cartItem1.date_expired.to_date).to eq(Date.yesterday)
+    end
+    it "creates a flash message" do
+      expect(response.flash[:notice]).to eq("Expiration Date Updated")
+    end
+    it "redirects to the request manager page" do
+      expect(response).to redirect_to(previous_requests_path)
     end
   end
 

--- a/spec/controllers/morphosource/my/requests_controller_spec.rb
+++ b/spec/controllers/morphosource/my/requests_controller_spec.rb
@@ -141,12 +141,6 @@ RSpec.describe Morphosource::My::RequestsController, :type => :controller  do
           expect(cartItem1.in_cart).to be(false)
         end
 
-        it 'creates a new cart item' do
-          expect{
-            process :request_again, method: :get, params: { item_id: cartItem1.id }
-          }.to change{CartItem.count}.by(1)
-        end
-
         it 'assigns the correct attribute values to the new cart item' do
           item = CartItem.last
           work = Media.find(cartItem1.work_id)
@@ -165,6 +159,14 @@ RSpec.describe Morphosource::My::RequestsController, :type => :controller  do
 
         it "reloads the page" do
           expect(response).to redirect_to("original_page")
+        end
+      end
+
+      context 'one item in group has already been requested' do
+        it 'creates a new cart item' do
+          expect{
+            process :request_item, method: :put, params: { batch_document_ids: [cartItem3.id,cartItem7.id,cartItem1.id] }
+          }.to change{CartItem.count}.by(1)
         end
       end
     end
@@ -255,24 +257,36 @@ RSpec.describe Morphosource::My::RequestsController, :type => :controller  do
   end
 
   describe "PUT #cancel_request" do
-
     before do
       request.env["HTTP_REFERER"] = "original_page"
       put :cancel_request, params: { item_id: cartItem1.id }
     end
-
     it "marks the cart item as canceled" do
       cartItem1.reload
       expect(cartItem1.date_canceled.to_date).to eq(Date.today)
     end
-
     it 'creates a new flash message' do
       expect(response.flash[:notice]).to eq("Request Canceled")
     end
-
     it "reloads the page" do
       expect(response).to redirect_to("original_page")
     end
+  end
 
+  describe "PUT #move_to_cart" do
+    before do
+      request.env["HTTP_REFERER"] = "original_page"
+      put :move_to_cart, params: { item_id: cartItem5.id }
+    end
+    it "marks the cart item as in_cart" do
+      cartItem5.reload
+      expect(cartItem5.in_cart).to be(true)
+    end
+    it 'creates a new flash message' do
+      expect(response.flash[:notice]).to eq("Item Moved to Cart")
+    end
+    it "reloads the page" do
+      expect(response).to redirect_to("original_page")
+    end
   end
 end

--- a/spec/support/cart_items/shared_context_for_cart_items.rb
+++ b/spec/support/cart_items/shared_context_for_cart_items.rb
@@ -11,7 +11,7 @@ RSpec.shared_context 'cart items', :shared_context => :metadata do
   let(:work6)         { Media.create(id: "fff", title: ["Test Work Title"], depositor: "test@test.com", fileset_accessibility: ['']) }
   let(:work7)         { Media.create(id: "ggg", title: ["Test Work Title"], depositor: "test@test.com", fileset_accessibility: ['restricted_download']) }
 
-  let(:cartItem1)     { CartItem.create( media_cart_id: media_cart.id, work_id: work1.id, in_cart: true, date_requested: Date.yesterday, date_downloaded: Date.yesterday, restricted: true) }
+  let(:cartItem1)     { CartItem.create( media_cart_id: media_cart.id, work_id: work1.id, in_cart: true, date_requested: Date.yesterday, date_downloaded: Date.yesterday, restricted: true, date_approved: Date.yesterday, date_expired: Date.tomorrow) }
   let(:cartItem2)     { CartItem.create( media_cart_id: media_cart.id, work_id: work2.id, in_cart: true, date_downloaded: Date.yesterday, restricted: false) }
   let(:cartItem3)     { CartItem.create( media_cart_id: media_cart.id, work_id: work3.id, in_cart: true, date_downloaded: nil, restricted: true) }
   let(:cartItem4)     { CartItem.create( media_cart_id: media_cart.id, work_id: work4.id, in_cart: false, date_downloaded: Date.yesterday, restricted: false) }

--- a/spec/support/cart_items/shared_examples_for_cart_items.rb
+++ b/spec/support/cart_items/shared_examples_for_cart_items.rb
@@ -14,15 +14,18 @@ RSpec.shared_examples '#get_items instance variables' do |page|
   let(:docs)  { { 'downloads' => [doc1,doc2,doc4],
                   'media cart' => [doc1,doc2,doc3],
                   'requests' => [doc1,doc5],
-                  'request manager' => [doc1,doc5] } }
+                  'request manager' => [doc5],
+                  'previous requests' => [doc1]} }
   let(:items) { { 'downloads' => [cartItem1,cartItem2,cartItem4],
                   'media cart' => [cartItem1,cartItem2,cartItem3],
                   'requests' => [cartItem1,cartItem5],
-                  'request manager' => [cartItem1,cartItem5] } }
+                  'request manager' => [cartItem5],
+                  'previous requests' => [cartItem1] } }
   let(:count) { { 'downloads' => "3 Items",
                   'media cart' => "3 Items",
                   'requests' => "2 Items",
-                  'request manager' => "2 Items" } }
+                  'request manager' => "1 Item",
+                  'previous requests' => "1 Item" } }
 
   it 'retrieves all the correct solr documents' do
     expect(subject.instance_variable_get(:@solr_docs)).to match_array(docs[page])


### PR DESCRIPTION
- separate tabs for new and decided requests
- manager can set expiration date when single or batch approving requests
- manager can edit the expiration date for previous requests with status 'approved' or 'expired'
- some additional refactoring of request-related controllers