### PR TITLE
MR-566: Update showcase media buttons

### DIFF
--- a/app/controllers/morphosource/my/cart_items_controller.rb
+++ b/app/controllers/morphosource/my/cart_items_controller.rb
@@ -9,26 +9,25 @@ module Morphosource
 
       before_action :get_curation_concern, only: [:create]
 
-      # Used by Add to Cart button on Work show page
+      # Used by Add to Cart button on Work showcase page
       def create
         work = @curation_concern
         unless work_already_in_cart?(work.id)
-          item = create_item(params,work)
-          if item.restricted? && user_is_approver?(item)
-            unrestrict(item)
+          if work_requested?(work.id)
+            item = find_requested_item(work.id)
+            mark_as('in_cart',item,date: true)
+          else
+            item = create_cart_item(work.id)
+            if item.restricted? && user_is_approver?(item)
+              unrestrict(item)
+            end
           end
           flash[:notice] = 'Item Added to Cart'
         else
-          flash[:alert] = 'Item Already in Cart'
+          flash[:alert] = 'Item Already in Cart or Requested'
         end
         after_create_response(work)
       end
-
-      private
-
-        def create_item(params,work)
-          CartItem.create({:media_cart_id => params[:media_cart_id], :work_id => work.id, :restricted => work.restricted?})
-        end
 
     end
   end

--- a/app/controllers/morphosource/my/downloads_controller.rb
+++ b/app/controllers/morphosource/my/downloads_controller.rb
@@ -14,6 +14,7 @@ module Morphosource
         get_items_by_id
         get_duplicate_requests
         create_new_items(@items,nil)
+        move_active_requests_to_cart
         flash[:notice] = duplicates_flash
         redirect_to main_app.my_cart_path
       end
@@ -39,14 +40,30 @@ module Morphosource
       end
 
       def duplicates_flash
-        "#{count_text(@count)} Added to Cart#{duplicates_text(@duplicate_requests+@duplicates_in_cart)}"
+        "#{count_text(@count)} Added to Cart#{duplicates_text(@duplicate_requests+@duplicates_in_cart)}#{active_requests_text}"
       end
 
       def duplicates_text(duplicates)
         if duplicates.count > 0
-          "; #{count_text(duplicates.count)}: #{duplicates.join(', ')} Already in Your Cart."
+          "; #{count_text(duplicates.count)}: #{duplicates.join(', ')} Already in Your Cart"
         else
           ''
+        end
+      end
+
+      def active_requests_text
+        if @active_requests_moved.count > 0
+          "; #{count_text(@active_requests_moved.count)} Already Requested and Moved to Your Cart."
+        else
+          '.'
+        end
+      end
+
+      def move_active_requests_to_cart
+        @items.each do |item|
+          if item.active_request? && item.in_cart == false
+            mark_as('in_cart',item,date: true)
+          end
         end
       end
 

--- a/app/controllers/morphosource/my/media_carts_controller.rb
+++ b/app/controllers/morphosource/my/media_carts_controller.rb
@@ -27,7 +27,7 @@ module Morphosource
       private
 
       def get_downloadable_items
-        @items = id_params ? get_items_by_id(id_params) & unrestricted_items : unrestricted_items
+        @items = id_params ? get_items_by_id(id_params) & downloadable_items : downloadable_items
       end
 
       def destroy_flash
@@ -36,7 +36,7 @@ module Morphosource
 
       def remove_from_cart
         @items.each do |item|
-          if (item.date_downloaded? || item.date_requested?)
+          if item.date_downloaded? || item.date_requested?
             item.in_cart = false
             item.save
           else

--- a/app/controllers/morphosource/my/requests_controller.rb
+++ b/app/controllers/morphosource/my/requests_controller.rb
@@ -12,7 +12,7 @@ module Morphosource
       end
 
       def request_item
-        re_request(requested(@items))
+        re_request(inactive(@items))
         mark_as('requested',unrequested(@items))
         flash[:notice] = item_count_text.concat(' Requested')
         redirect_back(fallback_location: my_requests_path)
@@ -34,6 +34,38 @@ module Morphosource
         flash[:notice] = "Item Moved to Cart"
         redirect_back(fallback_location: my_requests_path)
       end
+
+      # Request download from media showcase page
+      def request_work
+        work_id = params[:work_id]
+        if work_already_in_cart?(work_id)
+          item = find_item_in_cart(work_id)
+          if item_is_unrequested?(item)
+            mark_as('requested',item)
+          else
+            re_request(item)
+          end
+        else
+          create_new_requested_item(work_id)
+        end
+        redirect_back(fallback_location: my_requests_path)
+      end
+
+      private
+
+        def item_is_unrequested?(item)
+          item.date_requested == nil
+        end
+
+        def find_item_in_cart(work_id)
+          current_user.items_in_cart.find{ |i| i.work_id == work_id }
+        end
+
+        def create_new_requested_item(work_id)
+          item = create_cart_item(work_id)
+          mark_as('requested',item)
+          mark_as('in_cart',item,date: true)
+        end
 
     end
   end

--- a/app/helpers/morphosource/cart_item_helper.rb
+++ b/app/helpers/morphosource/cart_item_helper.rb
@@ -1,5 +1,52 @@
 module Morphosource::CartItemHelper
 
+  def edit_work_button(presenter)
+    link_to "Edit", edit_polymorphic_path([main_app, presenter]), class: 'btn btn-default'
+  end
+
+  def download_button(id)
+    link_to t('hyrax.file_sets.actions.download'), main_app.zip_hyrax_media_index_path(ids: [id]) , class: 'btn btn-default', role: 'button', download: true, target: '_blank'
+  end
+
+  def request_download_button(id)
+    link_to 'Request download', main_app.request_work_path(work_id: id), class: 'btn btn-default', :method => :post, role: 'button'
+  end
+
+  def download_requested_button
+    link_to 'Download Requested','', class: 'btn btn-default', role: 'button', disabled: true
+  end
+
+  def choose_download_button(id)
+    if current_user.downloadable_item_work_ids.include?(id)
+      download_button(id)
+    elsif current_user.my_active_requests_work_ids.include?(id)
+      download_requested_button
+    else
+      request_download_button(id)
+    end
+  end
+
+  def in_cart_button
+    link_to "Item in Cart", main_app.my_cart_path, class: 'btn btn-default'
+  end
+
+  def add_to_cart_button(id)
+    # TODO: don't need media_cart_id
+    link_to "Add to Cart", main_app.add_to_cart_path(:work_id => id, :media_cart_id => current_user.media_cart.id, :work_type => "Media"), class: 'btn btn-default', :method => :post
+  end
+
+  def choose_cart_button(presenter)
+    if current_user.work_ids_in_cart.include? presenter.id
+      in_cart_button
+    else
+      add_to_cart_button(presenter.id)
+    end
+  end
+
+  def unavailable_for_download_button
+    link_to 'Download Unavailable','', class: 'btn btn-default', role: 'button', disabled: true
+  end
+
   # provide status label <span> element
   # arguments: label text, class, style
   def item_status_label(item)

--- a/app/models/cart_item.rb
+++ b/app/models/cart_item.rb
@@ -20,6 +20,16 @@ class CartItem < ApplicationRecord
     !self.restricted?
   end
 
+  def active_request?
+    statuses = ["Approved","Requested","Cleared"]
+    statuses.include?(self.request_status)
+  end
+
+  def inactive_request?
+    statuses = ["Canceled","Denied","Expired"]
+    statuses.include?(self.request_status)
+  end
+
   def request_status
     if self.date_canceled.present?
       "Canceled"
@@ -54,7 +64,7 @@ class CartItem < ApplicationRecord
 
   def expired?
     return false unless self.date_expired
-    self.date_expired < Time.now
+    self.date_expired.to_date < Date.today
   end
 
   def approved?

--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -43,8 +43,21 @@ class Media < Morphosource::Works::Base
     all_visibilities & file_visibilities
   end
 
+  #TODO: during development, previously imported media do not have fileset accessibility; assume they are open. This should be changed after all media have fileset accessibility
   def restricted?
-    fileset_accessibility.first == "restricted_download"
+    if fileset_accessibility
+      fileset_accessibility.first == "restricted_download"
+    else
+      false
+    end
+  end
+
+  def open?
+    if fileset_accessibility
+      fileset_accessibility.first == "open"
+    else
+      true
+    end
   end
 
   private

--- a/app/presenters/hyrax/media_presenter.rb
+++ b/app/presenters/hyrax/media_presenter.rb
@@ -14,7 +14,7 @@ module Hyrax
       :other_details, :imaging_event_creator, :imaging_event_date_created, :imaging_event_modality,
       :parent_media_id_list, :child_media_id_list,
       :sibling_media_id_list, :parent_media_count, :direct_parent_members, :this_media_member,
-      :processing_event_count, :data_managed_by, :download_permission, :ark, :doi, :lens, 
+      :processing_event_count, :data_managed_by, :download_permission, :ark, :doi, :lens,
       :processing_activity_count, :processing_activity_items,
       :raw_or_derived, :is_absentee_parent,
       :imaging_event_exist,

--- a/app/views/hyrax/media/_showcase_show_actions.html.erb
+++ b/app/views/hyrax/media/_showcase_show_actions.html.erb
@@ -1,37 +1,18 @@
 <div class="show-actions">
-  <% if presenter.editor? %>
-    <% # TODO: refactor after imported media have fileset_accessibility added %>
-    <div class="btn-group">
-      <% # todo: The download button should (if the work is under restricted download)
-         # instead display the text “Request Download” and should lead to the request download UI flow (TBA)
-         # for now, the presenter checks for the fileset_visibility to determine the ability
-      if presenter&.fileset_accessibility&.first == 'open' %>
-        <%= link_to t('hyrax.file_sets.actions.download'), main_app.zip_hyrax_media_index_path(ids: [presenter.id]) , class: 'btn btn-default', role: 'button', download: true, target: '_blank' %>
-      <% elsif presenter&.fileset_accessibility&.first == 'restricted_download' %>
-        <%= link_to 'Request download', 'TBD' , class: 'btn btn-default', role: 'button' %>
+  <div class="btn-group">
+    <% if signed_in? %>
+      <% if presenter.editor? || @curation_concern.open? %>
+        <%= download_button(presenter.id) %>
+        <%= choose_cart_button(presenter) %>
+      <% elsif @curation_concern.restricted? %>
+        <%= choose_download_button(presenter.id) %>
+        <%= choose_cart_button(presenter) %>
       <% else %>
-        <%= link_to t('hyrax.file_sets.actions.download'), main_app.zip_hyrax_media_index_path(ids: [presenter.id]) , class: 'btn btn-default', role: 'button', download: true, target: '_blank' %>
+        <%= unavailable_for_download_button %>
       <% end %>
-
-      <% if signed_in? %>
-        <% if @presenter.works_in_cart.include? params[:id] %>
-          <%= link_to "Item in Cart", main_app.my_cart_path, class: 'btn btn-default' %>
-        <% elsif (@presenter&.fileset_accessibility&.first == 'open' || @presenter&.fileset_accessibility&.first == 'restricted_download') %>
-          <%= link_to "Add to Cart", main_app.add_to_cart_path(:work_id => @presenter.id, :media_cart_id => current_user.media_cart.id, :work_type => "Media"), class: 'btn btn-default', :method => :post %>
-        <% else %>
-          <%= link_to "Add to Cart", main_app.add_to_cart_path(:work_id => @presenter.id, :media_cart_id => current_user.media_cart.id, :work_type => "Media"), class: 'btn btn-default', :method => :post %>
-        <% end %>
+      <% if presenter.editor? %>
+        <%= edit_work_button(presenter) %>
       <% end %>
-
-      <button type="button" class="btn dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-        Actions <span class="caret"></span>
-      </button>
-      <ul class="dropdown-menu">
-        <li>
-          <%= link_to "Edit", edit_polymorphic_path([main_app, presenter]), class: 'btn' %>
-        </li>
-      </ul>
-    </div>
-
-  <% end %>
+    <% end %>
+  </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -111,7 +111,7 @@ Rails.application.routes.draw do
       post 'new_taxonomy_submit'
     end
   end
-  
+
   # Route to flow initial page when using browser reload or back button
   get '/submissions/stage_biological_specimen', to: 'submissions#new'
   get '/submissions/stage_device', to: 'submissions#new'
@@ -145,6 +145,7 @@ Rails.application.routes.draw do
       get 'request_again', action: :request_again, controller: :requests, as: 'request_again'
       put 'cancel_request', action: :cancel_request, controller: :requests, as: 'cancel_request'
       put 'move_to_cart', action: :move_to_cart, controller: :requests
+      post 'request_work', action: :request_work, controller: :requests
 
       # request manager
       get 'dashboard/my/request_manager', action: :index, controller: :request_managers, as: 'request_manager'

--- a/spec/controllers/morphosource/my/requests_controller_spec.rb
+++ b/spec/controllers/morphosource/my/requests_controller_spec.rb
@@ -67,36 +67,44 @@ RSpec.describe Morphosource::My::RequestsController, :type => :controller  do
         end
       end
 
-      context 'the item has previously been requested' do
+      context 'the item is a previous request' do
+        let(:requested_work) { Media.create(id: "zzz", title: ["Test Media Work"], depositor: "test@test.com", fileset_accessibility: ['restricted_download'])}
+        let(:requested_item) { CartItem.create(media_cart_id: media_cart.id, work_id: requested_work.id, in_cart: true, date_requested: Date.yesterday, date_approved: Date.yesterday, date_expired: Date.yesterday, restricted: true)}
+        let(:put_params) { {item_id: requested_item.id} }
+
         before do
           request.env["HTTP_REFERER"] = "original_page"
-          put :request_item, params: { item_id: cartItem1.id }
+          allow(Media).to receive(:find).with('zzz').and_return(requested_work)
+          requested_item.touch
         end
 
         it 'marks the item as not being in the cart' do
-          cartItem1.reload
-          expect(cartItem1.in_cart).to be(false)
+          put :request_item, params: put_params
+          requested_item.reload
+          expect(requested_item.in_cart).to be(false)
         end
 
         it 'creates a new cart item' do
           expect{
-            process :request_again, method: :get, params: { item_id: cartItem1.id }
+            process :request_item, method: :put, params: { item_id: requested_item.id }
           }.to change{CartItem.count}.by(1)
         end
 
         it 'assigns the correct attribute values to the new cart item' do
+          put :request_item, params: put_params
           item = CartItem.last
-          work = Media.find(cartItem1.work_id)
+          work = requested_work
           expect(item.media_cart_id).to eq(current_user.media_cart.id)
           expect(item.work_id).to eq(work.id)
-          expect(item.in_cart).to be(true)
           expect(item.approver).to eq(work.depositor)
           expect(item.date_requested.to_date).to eq(Date.today)
-          expect(item.restricted).to be(work.restricted?)
+          expect(item.restricted).to be(true)
+          expect(item.in_cart).to be(true)
           expect(item.date_cleared).to be(nil)
         end
 
         it "reloads the page" do
+          put :request_item, params: put_params
           expect(response).to redirect_to("original_page")
         end
       end
@@ -126,6 +134,8 @@ RSpec.describe Morphosource::My::RequestsController, :type => :controller  do
 
       context 'some of the items have been requested before' do
         before do
+          cartItem1.date_expired = Date.yesterday
+          cartItem1.save
           request.env["HTTP_REFERER"] = "original_page"
           put :request_item, params: { batch_document_ids: [cartItem3.id,cartItem7.id,cartItem1.id] }
         end
@@ -163,6 +173,10 @@ RSpec.describe Morphosource::My::RequestsController, :type => :controller  do
       end
 
       context 'one item in group has already been requested' do
+        before do
+          cartItem1.date_expired = Date.yesterday
+          cartItem1.save
+        end
         it 'creates a new cart item' do
           expect{
             process :request_item, method: :put, params: { batch_document_ids: [cartItem3.id,cartItem7.id,cartItem1.id] }
@@ -176,6 +190,8 @@ RSpec.describe Morphosource::My::RequestsController, :type => :controller  do
 
     context "user requests one item again" do
       before do
+        cartItem1.date_expired = Date.yesterday
+        cartItem1.save
         request.env["HTTP_REFERER"] = "original_page"
         get :request_again, params: { item_id: cartItem1.id }
       end
@@ -210,11 +226,15 @@ RSpec.describe Morphosource::My::RequestsController, :type => :controller  do
 
     context "user requests multiple items again" do
       before do
+        cartItem1.date_expired = Date.yesterday
+        cartItem1.save
+        cartItem5.date_denied = Date.yesterday
+        cartItem5.save
         request.env["HTTP_REFERER"] = "original_page"
-        get :request_again, params: { batch_document_ids: [cartItem1.id,cartItem5] }
       end
 
       it "removes any items in the cart" do
+        get :request_again, params: { batch_document_ids: [cartItem1.id,cartItem5.id] }
         [cartItem1,cartItem5].each(&:reload)
         expect(cartItem1.in_cart).to be(false)
         expect(cartItem5.in_cart).to be(false)
@@ -227,6 +247,7 @@ RSpec.describe Morphosource::My::RequestsController, :type => :controller  do
       end
 
       it 'assigns the correct attribute values to the new cart items' do
+        get :request_again, params: { batch_document_ids: [cartItem1.id,cartItem5.id] }
         items = CartItem.limit(2).order('id desc')
         item1 = items[0]
         work1 = Media.find(item1.work_id)
@@ -251,6 +272,7 @@ RSpec.describe Morphosource::My::RequestsController, :type => :controller  do
       end
 
       it "reloads the page" do
+        get :request_again, params: { batch_document_ids: [cartItem1.id,cartItem5.id] }
         expect(response).to redirect_to("original_page")
       end
     end
@@ -287,6 +309,73 @@ RSpec.describe Morphosource::My::RequestsController, :type => :controller  do
     end
     it "reloads the page" do
       expect(response).to redirect_to("original_page")
+    end
+  end
+
+  describe "POST #request_work" do
+    context "work is not in the user's cart and hasn't been requested" do
+      let(:new_work)    { Media.create(id: 'zzz', fileset_accessibility: ["restricted_download"], depositor: 'test@test.com')}
+      let(:post_params) { { work_id: new_work.id } }
+      before do
+        request.env["HTTP_REFERER"] = "original_page"
+        allow(Media).to receive(:find).with('zzz').and_return(new_work)
+      end
+
+      it "creates a new CartItem" do
+        expect{
+          process :request_work, method: :post, params: post_params
+          }.to change{CartItem.count}.by(1)
+      end
+
+      it "creates the correct metadata" do
+        post :request_work, params: post_params
+        item = CartItem.last
+        expect(item.media_cart_id).to eq(media_cart.id)
+        expect(item.work_id).to eq(new_work.id)
+        expect(item.in_cart).to be(true)
+        expect(item.restricted).to be(new_work.restricted?)
+        expect(item.approver).to eq(new_work.depositor)
+      end
+    end
+    context "work is in the cart and hasn't been requested" do
+      let(:post_params) { {work_id: work3.id} }
+      before do
+        request.env["HTTP_REFERER"] = "original_page"
+        post :request_work, params: post_params
+        cartItem3.reload
+      end
+      it "marks the item as requested and leaves it in the cart" do
+        expect(cartItem3.in_cart).to be(true)
+        expect(cartItem3.date_requested.to_date).to eq(Date.today)
+      end
+      it "reloads the page" do
+        expect(response).to redirect_to("original_page")
+      end
+    end
+    context "work is in the cart, but is an inactive request (expired,denied,cleared,canceled)" do
+      let(:post_params) {{work_id: cartItem1.work_id}}
+      before do
+        request.env["HTTP_REFERER"] = "original_page"
+        cartItem1.date_expired = Date.yesterday
+        cartItem1.save
+      end
+
+      it "creates a new cart Item" do
+        expect{
+          process :request_work, method: :post, params: post_params
+        }.to change{CartItem.count}.by(1)
+      end
+
+      it "removes the original item from the cart" do
+        expect{
+          process :request_work, method: :post, params: post_params
+        }.to change{cartItem1.reload.in_cart}.from(true).to(false)
+      end
+
+      it "reloads the page" do
+        post :request_work, params: post_params
+        expect(response).to redirect_to("original_page")
+      end
     end
   end
 end

--- a/spec/models/media_spec.rb
+++ b/spec/models/media_spec.rb
@@ -123,42 +123,48 @@ RSpec.describe Media do
       end
     end
 
-    describe '#restricted?' do
+    describe '#restricted?, #open?' do
       context 'fileset_accessibility is open' do
         before do
           subject.fileset_accessibility = ["open"]
         end
         it { expect(subject.restricted?).to be(false) }
+        it { expect(subject.open?).to be(true) }
       end
       context 'fileset_accessibility is restricted_download' do
         before do
           subject.fileset_accessibility = ["restricted_download"]
         end
         it { expect(subject.restricted?).to be(true) }
+        it { expect(subject.open?).to be(false) }
       end
       context 'fileset_accessibility is preview_only' do
         before do
           subject.fileset_accessibility = ["preview_only"]
         end
         it { expect(subject.restricted?).to be(false) }
+        it { expect(subject.open?).to be(false) }
       end
       context 'fileset_accessibility is hidden' do
         before do
           subject.fileset_accessibility = ["hidden"]
         end
         it { expect(subject.restricted?).to be(false) }
+        it { expect(subject.open?).to be(false) }
       end
       context 'fileset_accessibility is private' do
         before do
           subject.fileset_accessibility = ["private"]
         end
         it { expect(subject.restricted?).to be(false) }
+        it { expect(subject.open?).to be(false) }
       end
-      context 'fileset_accessibility is empty' do
+      context 'fileset_accessibility is nil' do
         before do
-          subject.fileset_accessibility = [""]
+          allow(subject).to receive(:fileset_accessibility).and_return(nil)
         end
         it { expect(subject.restricted?).to be(false) }
+        it { expect(subject.open?).to be(true) }
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe User, type: :model do
   let(:cartItem1)     { CartItem.create(id: 1, media_cart_id: media_cart.id, work_id: "aaa", in_cart: true, restricted: true, date_cleared: Time.current) }
   let(:cartItem2)     { CartItem.create(id: 2, media_cart_id: media_cart.id, work_id: "bbb", in_cart: true, restricted: false) }
   let(:cartItem3)     { CartItem.create(id: 3, media_cart_id: media_cart.id, work_id: "ccc", in_cart: true, restricted: true, date_requested: Date.yesterday) }
-  let(:cartItem4)     { CartItem.create(id: 4, media_cart_id: media_cart.id, work_id: "ddd", in_cart: false, date_downloaded: Time.current) }
+  let(:cartItem4)     { CartItem.create(id: 4, media_cart_id: media_cart.id, work_id: "ddd", in_cart: false, restricted: false, date_downloaded: Time.current) }
   let(:cartItem5)     { CartItem.create(id: 5, media_cart_id: media_cart.id, work_id: "eee", in_cart: false, restricted: true, date_downloaded: Time.current, date_requested: Date.yesterday) }
 
   let(:allCartItems)  { [cartItem1, cartItem2, cartItem3, cartItem4, cartItem5] }
@@ -54,15 +54,15 @@ RSpec.describe User, type: :model do
 
   # where user is requestor
   describe '#my_requests' do
-    it { expect(user.my_requests).to match_array([cartItem3,cartItem5])}
+    it { expect(user.my_requests).to match_array([cartItem1,cartItem3,cartItem5])}
   end
 
   describe '#my_requests_ids' do
-    it { expect(user.my_requests_ids).to match_array([cartItem3.id,cartItem5.id])}
+    it { expect(user.my_requests_ids).to match_array([cartItem1.id,cartItem3.id,cartItem5.id])}
   end
 
   describe '#my_requests_work_ids' do
-    it { expect(user.my_requests_work_ids).to match_array([cartItem3.work_id,cartItem5.work_id])}
+    it { expect(user.my_requests_work_ids).to match_array([cartItem1.work_id,cartItem3.work_id,cartItem5.work_id])}
   end
 
   # where user is data owner/manager
@@ -87,6 +87,76 @@ RSpec.describe User, type: :model do
   describe '#downloaded_work_ids' do
     it "returns the work ids for items the user has downloaded" do
       expect(user.downloaded_work_ids).to match_array([cartItem4.work_id, cartItem5.work_id])
+    end
+  end
+
+  describe '#downloadable_items' do
+    it 'returns the items the user is allowed to download' do
+      expect(user.downloadable_items).to match_array([cartItem2,cartItem4])
+    end
+  end
+  describe '#downloadable_ids' do
+    it 'returns the ids for items the user is allowed to download' do
+      expect(user.downloadable_ids).to match_array([cartItem2.id, cartItem4.id])
+    end
+  end
+  describe '#downloadable_item_work_ids' do
+    it 'returns the work ids for items the user is allowed to download' do
+      expect(user.downloadable_item_work_ids).to match_array([cartItem2.work_id, cartItem4.work_id])
+    end
+  end
+  describe '#downloadable_items_in_cart' do
+    it "returns the items the user is allowed to download that are in the user's cart" do
+      expect(user.downloadable_items_in_cart).to match_array([cartItem2])
+    end
+  end
+  describe '#downloadable_ids_in_cart' do
+    it "returns the items ids the user is allowed to download that are in the user's cart" do
+      expect(user.downloadable_ids_in_cart).to match_array([cartItem2.id])
+    end
+  end
+
+  describe '#my_active_requests, #my_active_requests_work_ids, #previously_requested_items' do
+
+    let(:cartItem11)  { CartItem.new(id: 11, work_id: 'jjj', date_requested: Date.today)} #status = "Requested"
+    let(:cartItem12)  { CartItem.new(id: 12, work_id: 'kkk', date_requested: Date.today, date_approved: Date.today)} #status = "Approved"
+    let(:cartItem13)  { CartItem.new(id: 13, work_id: 'lll', date_requested: nil, date_cleared: Date.today)} #status = "Cleared"
+    let(:cartItem14)  { CartItem.new(id: 14, work_id: 'mmm', date_requested: Date.today, date_denied: Date.today)} #status = "Denied"
+    let(:cartItem15)  { CartItem.new(id: 15, work_id: 'nnn', date_requested: Date.today, date_approved: Date.today, date_expired: Date.yesterday )} #status = "Expired"
+    let(:cartItem16)  { CartItem.new(id: 16, work_id: 'ooo', date_requested: Date.today, date_canceled: Date.today)} #status = "Canceled"
+    let(:cart_items)  { [cartItem11,cartItem12,cartItem13,cartItem14,cartItem15,cartItem16] }
+
+    before do
+      allow(user).to receive(:cart_items).and_return(cart_items)
+    end
+
+    describe '#my_active_requests' do
+      it 'returns the items that have been requested, approved, or cleared' do
+        expect(user.my_active_requests).to match_array([cartItem11,cartItem12,cartItem13])
+      end
+      it 'does not return the items that have been denied, canceled, or are expired' do
+        expect(user.my_active_requests).not_to include(cartItem14,cartItem15,cartItem16)
+      end
+    end
+
+    describe '#my_active_requests_work_ids' do
+      it 'returns the work ids for items that have been requested, approved, or cleared' do
+        expect(user.my_active_requests_work_ids).to match_array([cartItem11.work_id,cartItem12.work_id,cartItem13.work_id])
+      end
+      it 'does not return the work ids for items that have been denied, canceled, or are expired' do
+        expect(user.my_active_requests_work_ids).not_to include(cartItem14.work_id,cartItem15.work_id,cartItem16.work_id)
+      end
+    end
+
+    describe '#previously_requested_items' do
+      before do
+        allow(data_owner).to receive(:requested_items).and_return(cart_items)
+      end
+
+      it 'returns the items that have status approved, denied, expired, cleared, and canceled' do
+        expect(data_owner.previously_requested_items).to match_array([cartItem12, cartItem13,cartItem14,cartItem15,cartItem16])
+      end
+      it { expect(data_owner.previously_requested_items).not_to include([cartItem11])}
     end
   end
 end

--- a/spec/routing/cart_items_routing_spec.rb
+++ b/spec/routing/cart_items_routing_spec.rb
@@ -60,6 +60,11 @@ RSpec.describe 'cart items routing', type: :routing do
     expect(:put => 'cancel_request').to route_to(route)
   end
 
+  it 'has a route to request download from the work page' do
+    route = { controller: 'morphosource/my/requests', action: 'request_work' }
+    expect(:post => 'request_work').to route_to(route)
+  end
+
   # request manager
 
   it 'has a route for the request manager page' do


### PR DESCRIPTION
Modifies behavior for the three buttons at the top of the Media Showcase page:
* Download/Request Download/Download Requested 
* Add to Cart/Item in Cart
* Edit

Adds:
* Download Unavailable

Download button:
Appears when:
- Media publication status is "open" or
- Viewer has edit privileges for the Media or
- Media publication status is "restricted", the user has requested download, and their request status is "Approved"

What it does: 
- downloads the item.

Request Download button:
Appears when:
- Media publication status is "restricted"

What it does:
- If a user has already added the Media to their cart, that cart item is located and requested. If the user has not already added it to their cart, a new item is created, added to their cart, and requested. 

Download Requested (disabled):
Appears when:
- User has an active download request, but their request has not yet been approved. 

What it does:
- nothing

Add to Cart button:
Appears when:
- Media is not in the user's cart

What it does: 
- If a user has an active request, that item is located and moved to the cart. If the user does not have an active request, a new cart item is created and added to the cart.

Item in Cart button:
Appears when:
- Media is in the user's cart 

What it does: 
- links to the user's media cart.

Unavailable for Download (disabled)
Appears when:
- Media publication status is not "open" or "restricted" and user is not an editor for the media. 

What it does:
- nothing