### PR TITLE
MR-571: Add publication status to works page

### DIFF
--- a/app/helpers/morphosource_helper.rb
+++ b/app/helpers/morphosource_helper.rb
@@ -1,5 +1,4 @@
 module MorphosourceHelper
-
   def current_controller
     current_uri = request.env['PATH_INFO']
     # to-do: might need to catch exception here for route not found
@@ -127,6 +126,23 @@ module MorphosourceHelper
 
   def is_number_with_decimal? string
     true if Float(string).to_f % 1 != 0 rescue false
+  end
+
+  def publication_badge(value)
+    Morphosource::PublicationBadge.new(value).render
+  end
+
+  def render_publication_status_badge(document)
+    media = Media.find(document.id)
+
+    path = edit_polymorphic_path([main_app, document], anchor: 'share')
+
+    link_to(
+      publication_badge(media.publication_status),
+      path,
+      id: "permission_#{document.id}",
+      class: 'visibility-link'
+    )
   end
 
 end

--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -43,7 +43,6 @@ class Media < Morphosource::Works::Base
     all_visibilities & file_visibilities
   end
 
-  #TODO: during development, previously imported media do not have fileset accessibility; assume they are open. This should be changed after all media have fileset accessibility
   def restricted?
     if fileset_accessibility
       fileset_accessibility.first == "restricted_download"
@@ -53,10 +52,36 @@ class Media < Morphosource::Works::Base
   end
 
   def open?
-    if fileset_accessibility
-      fileset_accessibility.first == "open"
+    accessibility = fileset_accessibility.first
+    unless accessibility.nil?
+      accessibility == "open"
+    # TODO: remove after migrated media have fileset_accessibility
     else
       true
+    end
+  end
+
+  def publication_status
+    fileset_accessibility = self.fileset_accessibility.first
+
+    case
+    when fileset_accessibility == "open"
+      "open"
+    when fileset_accessibility == "restricted_download"
+      "restricted"
+    when fileset_accessibility == "preview_only"
+      "preview"
+    when fileset_accessibility == "hidden"
+      "hidden"
+    when fileset_accessibility == "private"
+      "private"
+    when self.embargo && self.embargo.active?
+      "embargo"
+    when self.lease && self.lease.active?
+      "lease"
+      #TODO: remove after migrated media have fileset_accessibility values
+    when fileset_accessibility == nil
+      "open"
     end
   end
 

--- a/app/presenters/morphosource/publication_badge.rb
+++ b/app/presenters/morphosource/publication_badge.rb
@@ -1,0 +1,48 @@
+module Morphosource
+  class PublicationBadge
+      include ActionView::Helpers::TagHelper
+
+      PUBLICATION_LABEL_CLASS = {
+        open: "label-success",
+        restricted: "label-info",
+        preview: "label-info",
+        hidden: "label-info",
+        private: "label-danger",
+        embargo: "label-warning",
+        lease: "label-warning"
+      }
+
+      PUBLICATION_LABEL_STYLE = {
+        open: "",
+        restricted: "border-color: red;",
+        preview: "",
+        hidden: "border-color: black;",
+        private: "",
+        embargo: "background-color: black;",
+        lease: "background-color: black;"
+      }
+
+      def initialize(status)
+        @status = status
+      end
+
+      def render
+        content_tag(:span, text, class: "label #{dom_label_class}", style: "#{dom_label_style}")
+      end
+
+      private
+
+        def dom_label_class
+          PUBLICATION_LABEL_CLASS.fetch(@status.to_sym)
+        end
+
+        def dom_label_style
+          PUBLICATION_LABEL_STYLE.fetch(@status.to_sym)
+        end
+
+        def text
+          I18n.t("morphosource.publication_status.#{@status}.text")
+        end
+    
+  end
+end

--- a/app/views/hyrax/my/works/_default_group.html.erb
+++ b/app/views/hyrax/my/works/_default_group.html.erb
@@ -7,8 +7,7 @@
     <th><%= t("hyrax.dashboard.my.heading.title") %></th>
     <th><%= t("hyrax.dashboard.my.heading.date_uploaded") %></th>
     <th><%= t("hyrax.dashboard.my.heading.highlighted") %></th>
-    <th><%= t("hyrax.dashboard.my.heading.visibility") %></th>
-    <th><%= t("morphosource.dashboard.my.heading.file_visibility") %></th>
+    <th><%= t("morphosource.dashboard.my.heading.publication_status") %></th>
     <th><%= t("hyrax.dashboard.my.heading.action") %></th>
   </tr>
   </thead>

--- a/app/views/hyrax/my/works/_list_works.html.erb
+++ b/app/views/hyrax/my/works/_list_works.html.erb
@@ -32,17 +32,14 @@
   <td class="date"><%= document.date_uploaded %></td>
   <td class='text-center'>
     <span class="fa <%= current_user.trophies.where(work_id: document.id).exists? ? 'fa-star highlighted-work' : 'fa-star-o trophy-off' %>" aria-hidden="true"></span></td>
-  <td><%= render_visibility_link document %></td>
   <td>
-    <div style="display:flex; flex-direction: column; justify-content: space-around; align-items: flex-start;">
-      <% unless document.file_set_visibilities.nil? %>
-        <% document.file_set_visibilities.each do |visibility| %>
-          <%= visibility_badge(visibility) %>
-          <div style="height: 3px;"></div>
-        <% end %>
-      <% end %>
-    </div>
+    <% if document.hydra_model == Media %>
+      <%= render_publication_status_badge(document) %>
+    <% else %>
+      <%= render_visibility_link document %>
+    <% end %>
   </td>
+
   <td>
     <%= render 'work_action_menu', document: document %>
   </td>

--- a/config/locales/morphosource.en.yml
+++ b/config/locales/morphosource.en.yml
@@ -17,6 +17,7 @@ en:
         heading:
           file_visibility: 'File Visibility'
           date_downloaded: 'Date Downloaded'
+          publication_status: 'Publication Status'
     validation:
       missing:
         title: 'Your work must have a title.'
@@ -30,6 +31,21 @@ en:
         photogrammetry: 'Photogrammetry Image Series'
         mesh: 'Mesh or Point Cloud'
         other: 'Other'
+    publication_status:
+      open:
+        text: "Open"
+      restricted:
+        text: "Restricted"
+      preview:
+        text: "Preview"
+      hidden:
+        text: "Hidden"
+      private:
+        text: "Private"
+      embargo:
+        text: "Embargo"
+      lease:
+        text: "Lease"
     upload:
       change_access_message_html: "<p>You have changed the access level on work <i>%{curation_concern}</i>, making it accessible to other users or groups to view or edit.</p><p>All attached files are now being updated with the same access level.</p>"
       change_access_yes_message: Yes please.

--- a/spec/helpers/morphosource_helper_spec.rb
+++ b/spec/helpers/morphosource_helper_spec.rb
@@ -207,5 +207,83 @@ RSpec.describe MorphosourceHelper, type: :helper do
         end
       end
     end
+
+    describe '#render_publication_status_badge' do
+      let(:document)  { SolrDocument.new(id: 'aaa')}
+      let(:media)     { Media.new(id: 'aaa', title: ["Test Media Work"], visibility: 'open', fileset_visibility: [''])}
+      let(:model)     { Hyrax::SolrDocumentBehavior::ModelWrapper.new(Media,media.id) }
+
+      before do
+        allow(Media).to receive(:find).with(document.id).and_return(media)
+        allow(document).to receive(:to_model).and_return(model)
+      end
+
+      context 'media and files are open' do
+        before do
+          media.fileset_accessibility = ["open"]
+        end
+
+        it { expect(helper.render_publication_status_badge(document)).to eq("<a id=\"permission_aaa\" class=\"visibility-link\" href=\"/concern/media/aaa/edit#share\"><span class=\"label label-success\" style=\"\">Open</span></a>") }
+      end
+
+      context 'media is open, files are restricted' do
+        before do
+          media.fileset_accessibility = ["restricted_download"]
+        end
+
+        it { expect(helper.render_publication_status_badge(document)).to eq("<a id=\"permission_aaa\" class=\"visibility-link\" href=\"/concern/media/aaa/edit#share\"><span class=\"label label-info\" style=\"border-color: red;\">Restricted</span></a>") }
+      end
+
+      context 'media is open, files are preview only' do
+        before do
+          media.fileset_accessibility = ["preview_only"]
+        end
+
+        it { expect(helper.render_publication_status_badge(document)).to eq("<a id=\"permission_aaa\" class=\"visibility-link\" href=\"/concern/media/aaa/edit#share\"><span class=\"label label-info\" style=\"\">Preview</span></a>") }
+      end
+
+      context 'media is open, files are hidden' do
+        before do
+          media.fileset_visibility = ["restricted"]
+          media.fileset_accessibility = ['hidden']
+        end
+
+        it { expect(helper.render_publication_status_badge(document)).to eq("<a id=\"permission_aaa\" class=\"visibility-link\" href=\"/concern/media/aaa/edit#share\"><span class=\"label label-info\" style=\"border-color: black;\">Hidden</span></a>") }
+      end
+
+      context 'media and files are both private' do
+        before do
+          media.visibility = "restricted"
+          media.fileset_accessibility = ["private"]
+        end
+
+        it { expect(helper.render_publication_status_badge(document)).to eq("<a id=\"permission_aaa\" class=\"visibility-link\" href=\"/concern/media/aaa/edit#share\"><span class=\"label label-danger\" style=\"\">Private</span></a>") }
+      end
+
+      context 'media and files are under embargo' do
+        let(:embargo) { double("Embargo")}
+
+        before do
+          media.visibility = "restricted"
+          media.fileset_accessibility = ['']
+          allow(embargo).to receive(:active?).and_return(true)
+          allow(media).to receive(:embargo).and_return(embargo)
+        end
+
+        it { expect(helper.render_publication_status_badge(document)).to eq("<a id=\"permission_aaa\" class=\"visibility-link\" href=\"/concern/media/aaa/edit#share\"><span class=\"label label-warning\" style=\"background-color: black;\">Embargo</span></a>") }
+      end
+
+      context 'media and files are under a lease' do
+        let(:lease) { double("Lease")}
+
+        before do
+          media.fileset_accessibility = [""]
+          allow(lease).to receive(:active?).and_return(true)
+          allow(media).to receive(:lease).and_return(lease)
+        end
+
+        it { expect(helper.render_publication_status_badge(document)).to eq("<a id=\"permission_aaa\" class=\"visibility-link\" href=\"/concern/media/aaa/edit#share\"><span class=\"label label-warning\" style=\"background-color: black;\">Lease</span></a>") }
+      end
+    end
   end
 end


### PR DESCRIPTION
Replaces 'visibility' and 'file visibility' columns with 'publication status'. For Media works, displays custom publication statuses (open, restricted, preview, hidden, embargo, lease); for non-Media works, displays normal Hyrax visibility. 