### PR TITLE
MR-579: Downloading a media work from the showcase page records the download

### DIFF
--- a/app/controllers/morphosource/my/cart_items_controller.rb
+++ b/app/controllers/morphosource/my/cart_items_controller.rb
@@ -29,6 +29,22 @@ module Morphosource
         after_create_response(work)
       end
 
+      # used when downloading from the showcase page
+      def download
+        work_id = params[:work_id].first
+        if downloadable_item_for_work?(work_id)
+          item = find_downloadable_item(work_id)
+          if item.date_downloaded
+            create_downloaded_item(work_id)
+          else
+            mark_as('downloaded',item)
+          end
+        else
+          create_downloaded_item(work_id)
+        end
+        redirect_to main_app.zip_hyrax_media_index_path(ids: [work_id])
+      end
+
     end
   end
 end

--- a/app/controllers/morphosource/my/media_carts_controller.rb
+++ b/app/controllers/morphosource/my/media_carts_controller.rb
@@ -12,7 +12,13 @@ module Morphosource
 
       def download
         get_downloadable_items
-        mark_as('downloaded')
+        @items.each do |item|
+          if item.date_downloaded
+            create_downloaded_item(item.work_id)
+          else
+            mark_as('downloaded',item)
+          end
+        end
         get_work_ids_by_items
         redirect_to main_app.zip_hyrax_media_index_path(ids: @work_ids)
       end

--- a/app/controllers/morphosource/my/requests_controller.rb
+++ b/app/controllers/morphosource/my/requests_controller.rb
@@ -43,7 +43,7 @@ module Morphosource
 
       # Request download from media showcase page
       def request_work
-        work_id = params[:work_id]
+        work_id = params[:work_id].first
         if work_already_in_cart?(work_id)
           item = find_item_in_cart(work_id)
           if item_is_unrequested?(item)

--- a/app/helpers/morphosource/cart_item_helper.rb
+++ b/app/helpers/morphosource/cart_item_helper.rb
@@ -5,7 +5,7 @@ module Morphosource::CartItemHelper
   end
 
   def download_button(id)
-    link_to t('hyrax.file_sets.actions.download'), main_app.zip_hyrax_media_index_path(ids: [id]) , class: 'btn btn-default', role: 'button', download: true, target: '_blank'
+    link_to t('hyrax.file_sets.actions.download'), main_app.download_work_path(work_id: [id]), class: 'btn btn-default', download: true, target: "_blank", role: 'button'
   end
 
   def request_download_button(id)
@@ -95,7 +95,7 @@ module Morphosource::CartItemHelper
     when 'Downloadable'
       make_button(item,"Download Item",:download_items_path,"btn btn-info",:get,'')
     else
-      button_tag("Request Download", id:'request-button', class: 'btn btn-info', data: {toggle: 'modal', target: '#pageModal'})
+      button_tag("Request Download", id:'request-button', class: 'btn btn-info', data: {toggle: 'modal', target: '#pageModal', item_id: item.id})
     end
   end
 

--- a/app/models/cart_item.rb
+++ b/app/models/cart_item.rb
@@ -5,7 +5,7 @@ class CartItem < ApplicationRecord
   before_create :set_approver
 
   def requester
-    self.media_cart.user
+    media_cart.user
   end
 
   def requester_email
@@ -17,60 +17,60 @@ class CartItem < ApplicationRecord
   end
 
   def unrestricted?
-    !self.restricted?
+    !restricted?
   end
 
   def active_request?
-    return false if self.unrestricted?
+    return false if unrestricted?
     statuses = ["Approved","Requested","Cleared"]
     statuses.include?(self.request_status)
   end
 
   def inactive_request?
-    return false if self.unrestricted?
+    return false if unrestricted?
     statuses = ["Canceled","Denied","Expired"]
-    statuses.include?(self.request_status)
+    statuses.include?(request_status)
   end
 
   def request_status
-    if self.date_canceled.present?
+    if date_canceled?
       "Canceled"
-    elsif self.date_denied.present?
+    elsif date_denied?
       "Denied"
-    elsif self.expired?
+    elsif expired?
       "Expired"
-    elsif self.date_approved.present?
+    elsif date_approved?
       "Approved"
-    elsif self.date_cleared.present?
+    elsif date_cleared?
       "Cleared"
-    elsif self.date_requested.present?
+    elsif date_requested?
       "Requested"
-    elsif self.restricted?
+    elsif restricted?
       "Not Requested"
-    elsif self.downloadable?
+    elsif downloadable?
       "Downloadable"
     end
   end
 
   def downloadable?
-    self.unrestricted? || self.request_status == 'Approved'
+    unrestricted? || request_status == 'Approved'
   end
 
   def approving_user
-    User.find_by email: self.approver
+    User.find_by email: approver
   end
 
   def work
-    Media.find(self.work_id)
+    Media.find(work_id)
   end
 
   def expired?
-    return false unless self.date_expired
-    self.date_expired.to_date < Date.today
+    return false unless date_expired
+    date_expired.to_date < Date.today
   end
 
   def approved?
-    self.request_status == 'Approved'
+    request_status == 'Approved'
   end
 
   # for now, approver = depositor

--- a/app/views/morphosource/my/modals/request/_showcase_body.html.erb
+++ b/app/views/morphosource/my/modals/request/_showcase_body.html.erb
@@ -2,7 +2,7 @@
   <%= form_tag(main_app.request_work_path, method: :post, id: 'modal-form', "data-behavior" => 'batch-select-all', :class => "form-horizontal") do %>
     <%= label_tag 'intended use', 'Intended Use', :class => 'control-label' %>
     <%= text_field :intended_use, params[:use], :class => "form-control", required: true, minlength: 50 %>
-    <%= hidden_field :work_id, params[@curation_concern.id] %>
+    <%= hidden_field :work_id, params[:work_id], value: @curation_concern.id %>
 </div>
 <div class="modal-footer">
   <button type="button" id="modal-cancel" class="btn btn-danger" data-dismiss="modal">Cancel</button>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -129,6 +129,7 @@ Rails.application.routes.draw do
 
       # cart items
       post 'add_to_cart', action: :create, controller: :cart_items
+      get 'download_work', action: :download, controller: :cart_items
 
       # media cart
       get 'dashboard/my/cart', action: :index, controller: :media_carts, as: 'my_cart'

--- a/lib/morphosource/my/cart_items_behavior.rb
+++ b/lib/morphosource/my/cart_items_behavior.rb
@@ -190,8 +190,12 @@ module Morphosource
         works.each do |work|
           unless work_in_cart_or_requested?(work.id)
             item = create_cart_item(work.id)
-            mark_as('requested',item,date: value)
-            mark_as('note',item,date: @intended_use)
+            if user_is_approver?(item)
+              unrestrict(item)
+            elsif requested == 'requested'
+              mark_as('requested',item,date: value)
+              mark_as('note',item,date: @intended_use)
+            end
             @count += 1
           else
             if work_requested?(work.id) && !work_already_in_cart?(work.id)
@@ -203,8 +207,18 @@ module Morphosource
         end
       end
 
+      def create_downloaded_item(work_id)
+        item = create_cart_item(work_id)
+        mark_as('in_cart',item,date: false)
+        mark_as('downloaded',item)
+      end
+
       def work_in_cart_or_requested?(work_id)
         work_already_in_cart?(work_id) || work_requested?(work_id)
+      end
+
+      def downloadable_item_for_work?(work_id)
+        downloadable_item_work_ids.include?(work_id)
       end
 
       def work_requested?(work_id)
@@ -212,7 +226,11 @@ module Morphosource
       end
 
       def find_requested_item(work_id)
-        current_user.my_active_requests.find{|item| item.work_id == work_id}
+        my_active_requests.find{|item| item.work_id == work_id}
+      end
+
+      def find_downloadable_item(work_id)
+        current_user.cart_items.find{|item| item.downloadable? && item.work_id == work_id}
       end
 
       def create_cart_item(work_id)
@@ -245,7 +263,7 @@ module Morphosource
         item.save
       end
 
-      delegate :downloaded_work_ids, :downloaded_items, :items_in_cart, :item_ids_in_cart, :my_requests_ids, :my_requests_work_ids, :requested_items, :previously_requested_items, :newly_requested_items, :requested_item_ids, :previously_requested_item_ids, :newly_requested_item_ids, :requested_items_work_ids, :previously_requested_items_work_ids, :newly_requested_items_work_ids, :work_ids_in_cart, :my_active_requests_work_ids, :newly_requested_items_user_ids, :previously_requested_items_user_ids, to: :current_user
+      delegate :downloaded_work_ids, :downloaded_items, :items_in_cart, :item_ids_in_cart, :my_requests_ids, :my_requests_work_ids, :my_active_requests, :my_active_requests_work_ids, :requested_items, :previously_requested_items, :newly_requested_items, :requested_item_ids, :previously_requested_item_ids, :newly_requested_item_ids, :requested_items_work_ids, :previously_requested_items_work_ids, :newly_requested_items_work_ids, :work_ids_in_cart,  :newly_requested_items_user_ids, :previously_requested_items_user_ids, :downloadable_item_work_ids, to: :current_user
     end
   end
 end

--- a/spec/controllers/morphosource/my/cart_items_controller_spec.rb
+++ b/spec/controllers/morphosource/my/cart_items_controller_spec.rb
@@ -105,4 +105,254 @@ RSpec.describe Morphosource::My::CartItemsController, :type => :controller  do
       end
     end
   end
+
+  describe '#GET download' do
+    let(:testwork)         { Media.create(id: 'xxx', title: ["Test Media Work"], depositor: "test@test.com")}
+    let(:cart_item)     { CartItem.create( media_cart_id: media_cart.id, work_id: testwork.id) }
+
+    before do
+      allow(Media).to receive(:find).with(testwork.id).and_return(testwork)
+      cart_item.touch
+    end
+
+    context 'the work is restricted' do
+      let(:get_params) {{:intended_use => ["Intended Use"], :work_id => [testwork.id]}}
+      before do
+        testwork.fileset_accessibility = ["restricted_download"]
+        testwork.save
+        cart_item.restricted = true
+        cart_item.save
+      end
+      context 'the user has an item in their cart for the work' do
+        before do
+          cart_item.in_cart = true
+          cart_item.save
+        end
+        context 'the item is approved' do
+          before do
+            cart_item.date_requested = Date.yesterday
+            cart_item.date_approved = Date.today
+            cart_item.save
+          end
+          context 'the item has already been downloaded' do
+            before do
+              cart_item.date_downloaded = Date.yesterday
+              cart_item.save
+            end
+            it 'creates a new downloaded cart item with the correct metadata' do
+              expect{
+                process :download, method: :get, params: get_params
+              }.to change{CartItem.count}.by(1)
+
+              item = CartItem.last
+              expect(item.date_downloaded.to_date).to eq(Date.today)
+              expect(item.restricted).to be(true)
+              expect(item.work_id).to eq(testwork.id)
+              expect(item.date_requested).to be(nil)
+            end
+            it 'does not change the date downloaded on the original item' do
+              get :download, params: get_params
+              expect(cart_item.reload.date_downloaded.to_date).to eq(Date.yesterday)
+            end
+          end
+          context 'the item has not been downloaded' do
+            it 'marks the item as downloaded' do
+              get :download, params: get_params
+              expect(cart_item.reload.date_downloaded).to_not be(nil)
+            end
+          end
+          context 'the user is the approver for the item' do
+            before do
+              cart_item.approver = current_user.email
+              cart_item.save
+            end
+            context 'the item has not been downloaded' do
+              it 'marks the item as downloaded' do
+                get :download, params: get_params
+                expect(cart_item.reload.date_downloaded).to_not be(nil)
+              end
+              it 'does not create a new cart item' do
+                expect{
+                  process :download, method: :get, params: get_params
+                }.not_to change{CartItem.count}
+              end
+            end
+            context 'the item has been downloaded' do
+              before do
+                cart_item.date_downloaded = Date.yesterday
+                cart_item.save
+              end
+              it 'creates a new cart item with the correct metadata' do
+                expect{
+                  process :download, method: :get, params: get_params
+                }.to change{CartItem.count}.by(1)
+
+                item = CartItem.last
+                expect(item.date_downloaded.to_date).to eq(Date.today)
+                expect(item.restricted).to be(true)
+                expect(item.work_id).to eq(testwork.id)
+                expect(item.date_requested).to be(nil)
+              end
+            end
+          end
+        end
+      end
+      context 'the user has an approved item for the work not in their cart' do
+        before do
+          cart_item.in_cart = false
+          cart_item.save
+        end
+        context 'the item is an approved request' do
+          before do
+            cart_item.date_requested = Date.yesterday
+            cart_item.date_approved = Date.yesterday
+            cart_item.save
+          end
+          context 'the item has been downloaded' do
+            before do
+              cart_item.date_downloaded = Date.yesterday
+              cart_item.save
+            end
+            it 'creates a new cart item with the correct metadata' do
+              expect{
+                process :download, method: :get, params: get_params
+              }.to change{CartItem.count}.by(1)
+
+              item = CartItem.last
+              expect(item.date_downloaded.to_date).to eq(Date.today)
+              expect(item.restricted).to be(true)
+              expect(item.work_id).to eq(testwork.id)
+              expect(item.date_requested).to be(nil)
+            end
+            it 'does not change the date downloaded for the original item' do
+              get :download, params: get_params
+              expect(cart_item.reload.date_downloaded.to_date).to eq(Date.yesterday)
+            end
+          end
+          context 'the item has not been downloaded' do
+            it 'marks the item as downloaded' do
+              get :download, params: get_params
+              expect(cart_item.reload.date_downloaded.to_date).to eq(Date.today)
+            end
+          end
+        end
+      end
+      context 'the user has an item in their cart and an inactive request' do
+        let(:cart_item2) { CartItem.create(media_cart_id: media_cart.id, work_id: testwork.id, in_cart: false, date_requested: Date.yesterday, date_canceled: Date.yesterday) }
+        before do
+          cart_item.in_cart = true
+          cart_item.save
+        end
+        context 'the item in their cart is approved' do
+          before do
+            cart_item.date_requested = Date.yesterday
+            cart_item.date_approved = Date.yesterday
+            cart_item.save
+          end
+          context 'the item in the cart has been downloaded' do
+            before do
+              cart_item.date_downloaded = Date.yesterday
+              cart_item.save
+            end
+            it 'creates a new cart item with the correct metadata' do
+              expect{
+                process :download, method: :get, params: get_params
+              }.to change{CartItem.count}.by(1)
+
+              item = CartItem.last
+              expect(item.date_downloaded.to_date).to eq(Date.today)
+              expect(item.restricted).to be(true)
+              expect(item.work_id).to eq(testwork.id)
+              expect(item.date_requested).to be(nil)
+            end
+            it 'does not change the original cart items' do
+              get :download, params: get_params
+              expect(cart_item.reload.date_downloaded.to_date).to eq(Date.yesterday)
+              expect(cart_item2.reload.date_downloaded).to be(nil)
+            end
+          end
+          context 'the item in the cart has not been downloaded' do
+            it 'marks the item in the cart as downloaded' do
+              get :download, params: get_params
+              expect(cart_item.reload.date_downloaded.to_date).to eq(Date.today)
+            end
+            it 'does not create a new cart item' do
+              expect{
+                process :download, method: :get, params: get_params
+              }.not_to change{CartItem.count}
+            end
+            it 'does not alter the item not in the cart' do
+              get :download, params: get_params
+              expect(cart_item2.reload.date_downloaded).to be(nil)
+            end
+          end
+        end
+      end
+    end
+    context 'the work is unrestricted' do
+      let(:get_params) {{:intended_use => ["Intended Use"], :work_id => [testwork.id]}}
+      before do
+        testwork.fileset_accessibility = [""]
+        testwork.save
+        cart_item.restricted = false
+        cart_item.save
+      end
+
+      context 'the user has an item in their cart' do
+        before do
+          cart_item.in_cart = true
+          cart_item.save
+        end
+        context 'the item has not been downloaded' do
+          it 'marks the item as downloaded' do
+            get :download, params: get_params
+            expect(cart_item.reload.date_downloaded.to_date).to eq(Date.today)
+          end
+          it 'does not create another cart item' do
+            expect{
+              process :download, method: :get, params: get_params
+            }.not_to change{CartItem.count}
+          end
+        end
+        context 'the item has been downloaded' do
+          before do
+            cart_item.date_downloaded = Date.yesterday
+            cart_item.save
+          end
+          it 'creates a new downloaded item with the correct metadata' do
+            expect{
+              process :download, method: :get, params: get_params
+            }.to change{CartItem.count}.by(1)
+
+            item = CartItem.last
+            expect(item.date_downloaded.to_date).to eq(Date.today)
+            expect(item.restricted).to be(false)
+            expect(item.work_id).to eq(testwork.id)
+            expect(item.date_requested).to be(nil)
+          end
+        end
+      end
+      context 'the user does not have an item in their cart' do
+        before do
+          cart_item.destroy
+        end
+        context 'the user has downloaded the work before' do
+          let(:cart_item3) { CartItem.create( media_cart_id: media_cart.id, work_id: testwork.id, in_cart: false, date_downloaded: Date.yesterday) }
+
+          it 'creates a new downloaded item' do
+            expect{
+              process :download, method: :get, params: get_params
+            }.to change{CartItem.count}.by(1)
+          end
+        end
+        context 'the user has not downloaded the work before' do
+          it 'creates a new downloaded item' do
+            expect{
+              process :download, method: :get, params: get_params
+            }.to change{CartItem.count}.by(1)
+          end
+        end
+      end
+    end
+  end
 end

--- a/spec/controllers/morphosource/my/media_carts_controller_spec.rb
+++ b/spec/controllers/morphosource/my/media_carts_controller_spec.rb
@@ -45,6 +45,8 @@ RSpec.describe Morphosource::My::MediaCartsController, :type => :controller  do
 
       context 'the item is unrestricted' do
         before do
+          cartItem2.date_downloaded = nil
+          cartItem2.save
           get :download, params: {item_id: cartItem2.id}
         end
 
@@ -92,6 +94,8 @@ RSpec.describe Morphosource::My::MediaCartsController, :type => :controller  do
     context 'the user batch-selects items to download' do
       context 'the selected items are unrestricted' do
         before do
+          cartItem2.date_downloaded = nil
+          cartItem2.save
           get :download, params: { batch_document_ids: [cartItem2.id] }
         end
         it "sets the items' date_downloaded" do
@@ -134,6 +138,8 @@ RSpec.describe Morphosource::My::MediaCartsController, :type => :controller  do
 
       context 'the selected items are a mix of restricted and unrestricted' do
         before do
+          cartItem2.date_downloaded = nil
+          cartItem2.save
           get :download, params: { batch_document_ids: [cartItem2.id,cartItem3.id] }
         end
         it "sets only the unrestricted item's date_downloaded" do
@@ -157,9 +163,10 @@ RSpec.describe Morphosource::My::MediaCartsController, :type => :controller  do
     context 'the user uses the download all button' do
       context 'the cart has only unrestricted items' do
         before do
-          restricted_items = [cartItem1,cartItem3]
+          restricted_items = [cartItem1,cartItem2,cartItem3]
           restricted_items.each do |item|
             item.restricted = false
+            item.date_downloaded = nil
             item.save
           end
           get :download, params: {}
@@ -202,6 +209,8 @@ RSpec.describe Morphosource::My::MediaCartsController, :type => :controller  do
 
       context 'the page has a mix of restricted and unrestricted items' do
         before do
+          cartItem2.date_downloaded = nil
+          cartItem2.save
           get :download, params: {}
         end
         it "sets only the unrestricted items' date_downloaded" do

--- a/spec/controllers/morphosource/my/requests_controller_spec.rb
+++ b/spec/controllers/morphosource/my/requests_controller_spec.rb
@@ -340,7 +340,7 @@ RSpec.describe Morphosource::My::RequestsController, :type => :controller  do
   describe "POST #request_work" do
     context "work is not in the user's cart and hasn't been requested" do
       let(:new_work)    { Media.create(id: 'zzz', fileset_accessibility: ["restricted_download"], depositor: 'test@test.com')}
-      let(:post_params) { { work_id: new_work.id, intended_use: ["Intended Use"] } }
+      let(:post_params) { { work_id: [new_work.id], intended_use: ["Intended Use"] } }
       before do
         request.env["HTTP_REFERER"] = "original_page"
         allow(Media).to receive(:find).with('zzz').and_return(new_work)
@@ -364,7 +364,7 @@ RSpec.describe Morphosource::My::RequestsController, :type => :controller  do
       end
     end
     context "work is in the cart and hasn't been requested" do
-      let(:post_params) { {work_id: work3.id, intended_use: ["Intended Use"]} }
+      let(:post_params) { {work_id: [work3.id], intended_use: ["Intended Use"]} }
       before do
         request.env["HTTP_REFERER"] = "original_page"
         post :request_work, params: post_params
@@ -380,7 +380,7 @@ RSpec.describe Morphosource::My::RequestsController, :type => :controller  do
       end
     end
     context "work is in the cart, but is an inactive request (expired,denied,cleared,canceled)" do
-      let(:post_params) {{work_id: cartItem1.work_id, intended_use: ["Intended Use"]}}
+      let(:post_params) {{work_id: [cartItem1.work_id], intended_use: ["Intended Use"]}}
       before do
         request.env["HTTP_REFERER"] = "original_page"
         cartItem1.date_expired = Date.yesterday

--- a/spec/helpers/morphosource/cart_item_helper_spec.rb
+++ b/spec/helpers/morphosource/cart_item_helper_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe Morphosource::CartItemHelper, type: :helper do
         %(<span class=\"label label-info\" style=\"background-color: teal;\">Not Requested</span>)
       end
       let(:button_content) do
-        %(<button name=\"button\" type=\"submit\" id=\"request-button\" class=\"btn btn-info\" data-toggle=\"modal\" data-target=\"#pageModal\">Request Download</button>)
+        %(<button name=\"button\" type=\"submit\" id=\"request-button\" class=\"btn btn-info\" data-toggle=\"modal\" data-target=\"#pageModal\" data-item-id=\"0\">Request Download</button>)
       end
 
       it 'creates a "Not Requested" label' do
@@ -181,7 +181,7 @@ RSpec.describe Morphosource::CartItemHelper, type: :helper do
     end
     context "item is in the user's cart, has been requested, and has been approved" do
       it 'displays the download button' do
-        expect(choose_download_button('aaa')).to eq("<a class=\"btn btn-default\" role=\"button\" download=\"true\" target=\"_blank\" href=\"/concern/media/zip?ids%5B%5D=aaa\">Download</a>")
+        expect(choose_download_button('aaa')).to eq("<a class=\"btn btn-default\" download=\"true\" target=\"_blank\" role=\"button\" href=\"/download_work?work_id%5B%5D=aaa\">Download</a>")
       end
     end
   end


### PR DESCRIPTION
When a user downloads a work from the media showcase page, checks to see if the user already has an undownloaded item is in the cart or if there is an undownloaded active request for the work. If it finds one, it marks the item as downloaded. If it can't find one, it creates a new cart item and marks it as downloaded. 