### PR TITLE
MR-589: Investigate Why Download Stats Aren't Working

### DIFF
--- a/app/assets/javascripts/hyrax/ga_events.js
+++ b/app/assets/javascripts/hyrax/ga_events.js
@@ -3,9 +3,58 @@
 
 // Documentation: https://developers.google.com/analytics/devguides/collection/gtagjs/events
 
+// Download from Showcase Media Page
 $(document).on('click', '#file_download', function(e) {
   gtag('event', 'Downloaded', {
     'event_category': 'Files',
     'event_label': $(this).data('label')
   });
+});
+
+// Media Cart
+
+// Get Work Ids from Checkbox Inputs
+function getIds(inputs){
+  var ids = [];
+  inputs.each(function(){
+    let document_id = this.closest('tr').id
+    let n = document_id.lastIndexOf('_');
+    let work_id = document_id.substring(n+1);
+    if (work_id != "") {
+      ids.push(work_id)
+    }
+  });
+  return ids
+}
+
+// Send GTag
+function createGTags(workIds){
+  workIds.forEach(function(workId){
+    gtag('event', 'Downloaded', {
+      'event_category': 'Files',
+      'event_label': workId
+    });
+  });
+}
+
+// Media Cart - Download All
+function getUnrestrictedWorkIds() {
+  var allItems = $('#unrestricted_documents').find(':checkbox');
+  return getIds(allItems);
+}
+
+$(document).on('click', '#download-all', function(e) {
+  var workIds = getUnrestrictedWorkIds();
+  createGTags(workIds);
+});
+
+// Media Cart - Download Selected
+function getWorkIds() {
+  var checkedItems = $('#unrestricted_documents').find('input:checked');
+  return getIds(checkedItems);
+}
+
+$(document).on('click', '#download-selected', function(e) {
+  var workIds = getWorkIds();
+  createGTags(workIds);
 });

--- a/app/helpers/morphosource/cart_item_helper.rb
+++ b/app/helpers/morphosource/cart_item_helper.rb
@@ -5,7 +5,7 @@ module Morphosource::CartItemHelper
   end
 
   def download_button(id)
-    link_to t('hyrax.file_sets.actions.download'), main_app.download_work_path(work_id: [id]), class: 'btn btn-default', download: true, target: "_blank", role: 'button'
+    link_to t('hyrax.file_sets.actions.download'), main_app.download_work_path(work_id: [id]), class: 'btn btn-default', download: true, target: "_blank", role: 'button', id: 'file_download', data: { label: id }
   end
 
   def request_download_button(id)

--- a/app/presenters/hyrax/work_usage.rb
+++ b/app/presenters/hyrax/work_usage.rb
@@ -1,0 +1,30 @@
+# class WorkUsage follows the model established by FileUsage
+# Called by the stats controller, it finds cached work pageview data,
+# and prepares it for visualization in /app/views/stats/work.html.erb
+module Hyrax
+  class WorkUsage < StatsUsagePresenter
+    def initialize(id)
+      self.model = Hyrax::WorkRelation.new.find(id)
+    end
+
+    alias work model
+    delegate :to_s, to: :model
+
+    def total_pageviews
+      pageviews.reduce(0) { |total, result| total + result[1].to_i }
+    end
+
+    # Package data for visualization using JQuery Flot
+    def to_flot
+      [
+        { label: "Pageviews", data: pageviews }
+      ]
+    end
+
+    private
+
+      def pageviews
+        to_flots WorkViewStat.statistics(model, created, user_id)
+      end
+  end
+end

--- a/app/presenters/hyrax/work_usage.rb
+++ b/app/presenters/hyrax/work_usage.rb
@@ -10,6 +10,10 @@ module Hyrax
     alias work model
     delegate :to_s, to: :model
 
+    def total_downloads
+      downloads.reduce(0) { |total, result| total + result[1].to_i }
+    end
+
     def total_pageviews
       pageviews.reduce(0) { |total, result| total + result[1].to_i }
     end
@@ -17,7 +21,8 @@ module Hyrax
     # Package data for visualization using JQuery Flot
     def to_flot
       [
-        { label: "Pageviews", data: pageviews }
+        { label: "Pageviews", data: pageviews },
+        { label: "Downloads", data: downloads }
       ]
     end
 
@@ -26,5 +31,10 @@ module Hyrax
       def pageviews
         to_flots WorkViewStat.statistics(model, created, user_id)
       end
+
+      def downloads
+        to_flots(FileDownloadStat.statistics(model, created, user_id))
+      end
+
   end
 end

--- a/app/views/_ga.html.erb
+++ b/app/views/_ga.html.erb
@@ -2,17 +2,15 @@
 <%# Its successor analytics.js is also deprecated. Instead, use modern gtag.js tracking. %>
 <%# Meta tag added because Google analytics charts were not loading except on page refresh. %>
 <%= "<meta name='turbolinks-visit-control' content='reload'/>".html_safe %>
-<%
-if Hyrax.config.google_analytics_id?
-tracking_id = Hyrax.config.google_analytics_id
-%>
-<!-- Global site tag (gtag.js) - Google Analytics -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=<%= tracking_id %>"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', '<%= tracking_id %>', { 'anonymize_ip': true, 'transport_type': 'beacon' });
-</script>
+<% if Hyrax.config.google_analytics_id? %>
+  <% tracking_id = Hyrax.config.google_analytics_id %>
+  <!-- Global site tag (gtag.js) - Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=<%= tracking_id %>"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', '<%= tracking_id %>', { 'anonymize_ip': true, 'transport_type': 'beacon' });
+  </script>
 
 <% end %>

--- a/app/views/hyrax/stats/work.html.erb
+++ b/app/views/hyrax/stats/work.html.erb
@@ -1,0 +1,26 @@
+<!-- Adapted from jquery-flot examples https://github.com/flot/flot/blob/master/examples/visitors/index.html -->
+<script>
+//<![CDATA[
+
+  var hyrax_item_stats = <%= raw json_escape @stats.to_flot.to_json %>;
+
+//]]>
+</script>
+
+<%= content_tag :h1, @stats, class: "lower" %>
+
+<div class="row">
+  <div class="col-sm-12">
+    <%= content_tag :h2, "Work Analytics" %>
+    <div class="alert alert-info">
+      <i class="glyphicon glyphicon-signal large-icon"></i>
+      <%= content_tag :strong, @stats.total_pageviews %> views since <%= @stats.created.strftime("%B %-d, %Y") %>
+    </div>
+    <div class="stats-container">
+      <div id="usage-stats" class="stats-placeholder"></div>
+    </div>
+    <div class="stats-container" style="height:150px;">
+      <div id="overview" class="stats-placeholder"></div>
+    </div>
+  </div>
+</div>

--- a/app/views/hyrax/stats/work.html.erb
+++ b/app/views/hyrax/stats/work.html.erb
@@ -14,7 +14,7 @@
     <%= content_tag :h2, "Work Analytics" %>
     <div class="alert alert-info">
       <i class="glyphicon glyphicon-signal large-icon"></i>
-      <%= content_tag :strong, @stats.total_pageviews %> views since <%= @stats.created.strftime("%B %-d, %Y") %>
+      <%= content_tag :strong, @stats.total_pageviews %> views and <%= content_tag :strong, @stats.total_downloads %> downloads since <%= @stats.created.strftime("%B %-d, %Y") %>
     </div>
     <div class="stats-container">
       <div id="usage-stats" class="stats-placeholder"></div>

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -63,7 +63,7 @@ Hyrax.config do |config|
   # Defaults to false
   # Requires a Google Analytics id and OAuth2 keyfile.  See README for more info
   # config.analytics = false
-  config.analytics = ENV['TRACK_GOOGLE_ANALYTICS'] == 'true' ? true : false
+  config.analytics = ENV['TRACK_GOOGLE_ANALYTICS'] == 'true'
 
   # Google Analytics tracking ID to gather usage statistics
   # config.google_analytics_id = 'UA-99999999-1'
@@ -108,20 +108,20 @@ Hyrax.config do |config|
 
   # find blender in PATH variable.  If exists, set config.blender_path to it
   # if blender is not in PATH, get the path from BLENDER_PATH variable
-  # note that tool_path (e.g. used in blender.rb) is by default set to config.blender_path, but can 
+  # note that tool_path (e.g. used in blender.rb) is by default set to config.blender_path, but can
   # be overridden by an argument
-  begin  
-    blender_in_path = ENV.fetch("PATH").split(':').select{|path| path.include?('blender')} 
+  begin
+    blender_in_path = ENV.fetch("PATH").split(':').select{|path| path.include?('blender')}
     if blender_in_path.present?
       config.blender_path = blender_in_path.first
     else
       config.blender_path = ENV.fetch("BLENDER_PATH")
     end
-  rescue  
-    puts 'Error: unable to get Blender path from PATH or BLENDER_PATH'  
+  rescue
+    puts 'Error: unable to get Blender path from PATH or BLENDER_PATH'
     exit
-  end  
-  
+  end
+
   config.fiji_path = ENV.fetch("FIJI_PATH", "fiji")
 
   # Path to where derivative generation tmp files should be placed (temporary method)

--- a/spec/helpers/morphosource/cart_item_helper_spec.rb
+++ b/spec/helpers/morphosource/cart_item_helper_spec.rb
@@ -181,7 +181,7 @@ RSpec.describe Morphosource::CartItemHelper, type: :helper do
     end
     context "item is in the user's cart, has been requested, and has been approved" do
       it 'displays the download button' do
-        expect(choose_download_button('aaa')).to eq("<a class=\"btn btn-default\" download=\"true\" target=\"_blank\" role=\"button\" href=\"/download_work?work_id%5B%5D=aaa\">Download</a>")
+        expect(choose_download_button('aaa')).to eq("<a class=\"btn btn-default\" download=\"true\" target=\"_blank\" role=\"button\" id=\"file_download\" data-label=\"aaa\" href=\"/download_work?work_id%5B%5D=aaa\">Download</a>")
       end
     end
   end


### PR DESCRIPTION
- This ticket was prompted by User Stats for views and downloads not showing up. After investigation, it turns out that this doesn't happen automatically. If we want to get this going, we would need to set up a task to regularly match up google analytics data (page views and downloads by work) with the user who owns those works. 

- Updated ga_events.js to send work ids  instead of fileset ids for downloads to Google Analytics, and modified the Work stats related files to also include stats for downloads. This all seems to be working now, and stats can be viewed for a work by going to http://localhost:3000/works/WORK_ID/stats?locale=en