### PR TITLE
Install Alembic dependencies in Travis and add Python environment variable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,18 @@ before_install:
   - mkdir geckodriver
   - tar -xzf geckodriver-v0.21.0-linux64.tar.gz -C geckodriver
   - export PATH=$PATH:$PWD/geckodriver
+
+  # begin installing Alembic python dependencies --------
+  - sudo apt-get install python-pip
+  - sudo pip install numpy
+  - python -c 'import numpy; print(numpy.__version__)'
+  - sudo pip install Pillow
+  - python -c 'import PIL; print(PIL.__version__)'
+  - sudo pip install pydicom
+  - python -c 'import pydicom; print(pydicom.__version__)'
+  - export MORPHOSOURCE_PYTHON="python"
+  # end installing Alembic python dependencies --------
+
   # begin FITS setup --------
   - mkdir $TRAVIS_BUILD_DIR/download
   - cd $TRAVIS_BUILD_DIR/download


### PR DESCRIPTION
Current Travis "trusty" dist only has Python 3.4 as its Python 3, and installing a higher version is obnoxious. So for now we are sticking with Python 2 in Travis (Python 3 in Vagrant and Ansible Environments).