### PR TITLE
MR-620, MR-621: Create Team and Project Collection Types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@
 # ---------------------------------------------------
 
 /derivatives
+
+#ignore banners and logos added to collections 
+/public/branding

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -4,4 +4,43 @@ class Collection < ActiveFedora::Base
   # You can replace these metadata if they're not suitable
   include Hyrax::BasicMetadata
   self.indexer = Hyrax::CollectionWithBasicMetadataIndexer
+
+  after_create :create_collection_groups, if: :type_assigns_groups?
+
+  DEFAULT_GROUP_ROLES = ["managers", "depositors", "viewers"]
+
+  def type_assigns_groups?
+    team? || project?
+  end
+
+  # managers_group, depositors_group, and viewers_group methods
+  DEFAULT_GROUP_ROLES.each do |role|
+    define_method("#{role}_group") do
+      Role.find_by(name: id.concat("_#{role}"))
+    end
+  end
+
+  def team?
+    collection_type.title == "Team"
+  end
+
+  def project?
+    collection_type.title == "Project"
+  end
+
+  private
+
+    # Create manager/depositor/viewer roles for each Team/Project collection
+    def create_collection_groups
+      DEFAULT_GROUP_ROLES.each do |role|
+        Role.create(name: id.concat("_#{role}"))
+      end
+      add_depositor_to_managers
+    end
+
+    def add_depositor_to_managers
+      user = User.find_by(ms_id: depositor)
+      managers_group.users << user
+      managers_group.save
+    end
 end

--- a/config/initializers/morphosource/collection_form.rb
+++ b/config/initializers/morphosource/collection_form.rb
@@ -1,0 +1,34 @@
+# breaks unless require hyrax/search_state - should be fixed in Hyrax 3.0: https://github.com/samvera/hyrax/pull/3686
+require 'hyrax/search_state'
+Hyrax::Forms::CollectionForm.class_eval do
+
+  self.terms = [:title,
+                :creator,
+                :contributor,
+                :description,
+                :keyword,
+                :representative_id,
+                :thumbnail_id,
+                :based_near,
+                :related_url,
+                :visibility,
+                :collection_type_gid]
+
+  self.required_fields = [:title]
+
+  # Terms that appear above the accordion
+  def primary_terms
+    [:title, :description]
+  end
+
+  # Terms that appear within the accordion
+  def secondary_terms
+    [:creator,
+     :contributor,
+     :keyword,
+     :based_near,
+     :related_url]
+  end
+
+
+end

--- a/config/initializers/morphosource/nested_collection_query_service.rb
+++ b/config/initializers/morphosource/nested_collection_query_service.rb
@@ -1,0 +1,16 @@
+Hyrax::Collections::NestedCollectionQueryService.module_eval do
+
+  # Include both projects and teams in results if adding a project to another collection as a child or a team to another collection as a parent
+  def self.parent_and_child_can_nest?(parent:, child:, scope:)
+    return false if parent == child # Short-circuit
+    # Disable line below to allow projects to be nested within teams
+    # return false unless parent.collection_type_gid == child.collection_type_gid
+    if parent.collection_type_gid != child.collection_type_gid
+      return false unless parent.team? && child.project?
+    end
+    return false if available_parent_collections(child: child, scope: scope, limit_to_id: parent.id).none?
+    return false if available_child_collections(parent: parent, scope: scope, limit_to_id: child.id).none?
+    true
+  end
+
+end

--- a/config/initializers/morphosource/nested_collections_search_builder.rb
+++ b/config/initializers/morphosource/nested_collections_search_builder.rb
@@ -1,0 +1,35 @@
+Hyrax::Dashboard::NestedCollectionsSearchBuilder.class_eval do
+
+  # This is the original Hyrax method
+  def show_only_other_collections_of_the_same_collection_type(solr_parameters)
+    # override to allow projects to be nested within teams
+    show_only_valid_collection_types(solr_parameters)
+  end
+
+  # New method
+  # When adding a project as a child, return projects and teams
+  # When adding a team as a parent, return projects and teams
+  # Otherwise, return only collections of same type
+  def show_only_valid_collection_types(solr_parameters)
+    solr_parameters[:fq] ||= []
+    project_gid = Hyrax::CollectionType.find_by(title: "Project").gid
+    team_gid = Hyrax::CollectionType.find_by(title: "Team").gid
+    if nesting_project_in_team?
+      solr_parameters[:fq] += [
+        "-" + ActiveFedora::SolrQueryBuilder.construct_query_for_ids(limit_ids), ActiveFedora::SolrQueryBuilder.construct_query([[Collection.collection_type_gid_document_field_name, project_gid],[Collection.collection_type_gid_document_field_name, team_gid]], ' OR ')]
+    else
+      solr_parameters[:fq] += [
+        "-" + ActiveFedora::SolrQueryBuilder.construct_query_for_ids(limit_ids), ActiveFedora::SolrQueryBuilder.construct_query(Collection.collection_type_gid_document_field_name => @collection.collection_type_gid)]
+    end
+    solr_parameters[:fq] += limit_clause if limit_clause # add limits to prevent illegal nesting arrangements
+  end
+
+  private
+
+    def nesting_project_in_team?
+      return true if @collection.team? && @nest_direction == :as_child
+      return true if @collection.project? && @nest_direction == :as_parent
+      false
+    end
+
+end

--- a/config/initializers/morphosource/permissions_create_service.rb
+++ b/config/initializers/morphosource/permissions_create_service.rb
@@ -1,0 +1,25 @@
+Hyrax::Collections::PermissionsCreateService.module_eval do
+
+  # Assign new groups to manager/depositor/viewer access if collection is a Team or Project
+  def self.create_default(collection:, creating_user:, grants: [])
+    collection_type = Hyrax::CollectionType.find_by_gid!(collection.collection_type_gid)
+    if collection.type_assigns_groups?
+      access_grants = ms_access_grants_attributes(collection: collection, creating_user: creating_user, grants: grants)
+    else
+      access_grants = access_grants_attributes(collection_type: collection_type, creating_user: creating_user, grants: grants)
+    end
+    Hyrax::PermissionTemplate.create!(source_id: collection.id, access_grants_attributes: access_grants.uniq)
+    collection.reset_access_controls!
+  end
+
+  # Add auto-generated groups.
+  # Don't give creating_user individual manager status since they are already added to the manager group.
+  def self.ms_access_grants_attributes(collection:, creating_user:, grants:)
+    [
+      { agent_type: 'group', agent_id: admin_group_name, access: Hyrax::PermissionTemplateAccess::MANAGE },
+      { agent_type: 'group', agent_id: collection.managers_group.name, access: Hyrax::PermissionTemplateAccess::MANAGE },
+      { agent_type: 'group', agent_id: collection.depositors_group.name, access: Hyrax::PermissionTemplateAccess::DEPOSIT },
+      { agent_type: 'group', agent_id: collection.viewers_group.name, access: Hyrax::PermissionTemplateAccess::VIEW }
+    ] + managers_of_collection_type(collection_type: collection.collection_type) + grants
+  end
+end

--- a/lib/morphosource/collection_types/projects.rb
+++ b/lib/morphosource/collection_types/projects.rb
@@ -1,0 +1,24 @@
+module Morphosource
+  module CollectionTypes
+    module Projects
+
+      # Settings used by morphosource.rake when creating Project collection type
+      SETTINGS = {
+        title: "Project",
+        description: "Assortment of media and physical object records. Media and physical object records can belong to multiple projects. Multiple users or teams can manage projects.",
+        machine_id: "project",
+        nestable: true,
+        discoverable: true,
+        sharable: true,
+        allow_multiple_membership: true,
+        require_membership: false,
+        assigns_workflow: false,
+        assigns_visibility: true,
+        share_applies_to_new_works: true,
+        brandable: true,
+        badge_color: "#003880"
+      }
+
+    end
+  end
+end

--- a/lib/morphosource/collection_types/teams.rb
+++ b/lib/morphosource/collection_types/teams.rb
@@ -1,0 +1,24 @@
+module Morphosource
+  module CollectionTypes
+    module Teams
+
+      # Settings used by morphosource.rake when creating Team collection type
+      SETTINGS = {
+        title: "Team",
+        description: "Group of users belonging to the same institution, organization, department, collection, or lab. Teams can manage projects collectively.",
+        machine_id: "team",
+        nestable: true,
+        discoverable: true,
+        sharable: true,
+        allow_multiple_membership: true,
+        require_membership: false,
+        assigns_workflow: false,
+        assigns_visibility: true,
+        share_applies_to_new_works: true,
+        brandable: true,
+        badge_color: "#FF861F"
+      }
+
+    end
+  end
+end

--- a/lib/tasks/morphosource.rake
+++ b/lib/tasks/morphosource.rake
@@ -129,4 +129,12 @@ namespace :morphosource do
 
     admin.save
   end
+
+  desc 'Set up Team and Project collection types'
+  task :create_collection_types => :environment do
+    Hyrax::CollectionType.create(Morphosource::CollectionTypes::Teams::SETTINGS)
+    Hyrax::CollectionType.create(Morphosource::CollectionTypes::Projects::SETTINGS)
+    puts 'Team and Project collection types created'
+  end
+
 end

--- a/spec/config/collection_form_spec.rb
+++ b/spec/config/collection_form_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+RSpec.describe Hyrax::Forms::CollectionForm do
+  let(:terms) { [:title, :creator, :contributor, :description, :keyword, :representative_id, :thumbnail_id, :based_near, :related_url, :visibility, :collection_type_gid] }
+  let(:required_fields) { [:title] }
+  let(:primary_terms) { [:title, :description] }
+  let(:secondary_terms) { [:creator, :contributor, :keyword, :based_near, :related_url] }
+
+  describe 'class attributes' do
+
+    it 'has expected metadata terms' do
+      expect(described_class.terms).to match_array(terms)
+    end
+
+    it 'has expected required metadata terms' do
+      expect(described_class.required_fields).to match_array(required_fields)
+    end
+  end
+
+  describe 'instance methods' do
+
+    let(:collection) { Collection.new }
+    let(:ability) { double }
+    let(:repository) { double }
+
+    subject { described_class.new(collection, ability, repository)}
+
+    it 'has the expected primary metadata terms' do
+      expect(subject.primary_terms).to match_array(primary_terms)
+    end
+
+    it 'has the expected secondary metadata terms' do
+      expect(subject.secondary_terms).to match_array(secondary_terms)
+    end
+  end
+end

--- a/spec/config/nested_collection_query_service_spec.rb
+++ b/spec/config/nested_collection_query_service_spec.rb
@@ -1,0 +1,82 @@
+require 'rails_helper'
+
+RSpec.describe Hyrax::Collections::NestedCollectionQueryService do
+  let(:scope) { double('Scope') }
+  let(:team_collection_type) { Hyrax::CollectionType.create(title: "Team", machine_id: 88) }
+  let(:project_collection_type) { Hyrax::CollectionType.create(title: "Project", machine_id: 77) }
+  let(:another_collection_type) { Hyrax::CollectionType.create(title: "Another", machine_id: 99) }
+  # teams
+  let(:coll_a) { Collection.new(id: 'Collection_A', collection_type_gid: team_collection_type.gid )}
+  let(:coll_b) { Collection.new(id: 'Collection_B', collection_type_gid: team_collection_type.gid )}
+  # projects
+  let(:coll_c) { Collection.new(id: 'Collection_C', collection_type_gid: project_collection_type.gid )}
+  let(:coll_d) { Collection.new(id: 'Collection_D', collection_type_gid: project_collection_type.gid )}
+  # other
+  let(:coll_e) { Collection.new(id: 'Collection_E', collection_type_gid: another_collection_type.gid )}
+  let(:coll_f) { Collection.new(id: 'Collection_F', collection_type_gid: another_collection_type.gid )}
+
+  describe '.parent_and_child_can_nest?' do
+    subject { described_class.parent_and_child_can_nest?(parent: parent, child: child, scope: scope) }
+    describe 'given parent and child are nestable' do
+      describe 'all the other conditions pass' do
+        before do
+          allow(described_class).to receive_message_chain(:available_parent_collections, :none?).and_return(false)
+          allow(described_class).to receive_message_chain(:available_child_collections, :none?).and_return(false)
+        end
+        describe 'parent and child have different collection types' do
+          describe 'parent is a Team and child is a Project' do
+            let(:parent)  { coll_a }
+            let(:child)   { coll_c }
+            it 'returns true' do
+              expect(subject).to be(true)
+            end
+          end
+          describe 'parent is a Project and child is a Team' do
+            let(:parent)  { coll_c }
+            let(:child)   { coll_a }
+            it 'returns false' do
+              expect(subject).to be(false)
+            end
+          end
+          describe 'parent is a Team and child is Another' do
+            let(:parent)  { coll_a }
+            let(:child)   { coll_e }
+            it 'returns false' do
+              expect(subject).to be(false)
+            end
+          end
+          describe 'parent is Another and child is a Project' do
+            let(:parent)  { coll_e }
+            let(:child)   { coll_c }
+            it 'returns true' do
+              expect(subject).to be(false)
+            end
+          end
+        end
+        describe 'parent and child have the same collection types' do
+          describe 'parent and child are projects' do
+            let(:parent)  { coll_c }
+            let(:child)   { coll_d }
+            it 'returns true' do
+              expect(subject).to be(true)
+            end
+          end
+          describe 'parent and child are teams' do
+            let(:parent)  { coll_a }
+            let(:child)   { coll_b }
+            it 'returns true' do
+              expect(subject).to be(true)
+            end
+          end
+          describe 'parent and child are another type' do
+            let(:parent)  { coll_e }
+            let(:child)   { coll_f }
+            it 'returns true' do
+              expect(subject).to be(true)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/config/nested_collections_search_builder_spec.rb
+++ b/spec/config/nested_collections_search_builder_spec.rb
@@ -1,0 +1,100 @@
+require 'rails_helper'
+
+RSpec.describe Hyrax::Dashboard::NestedCollectionsSearchBuilder do
+  let(:team_collection_type) { Hyrax::CollectionType.create(title: "Team", machine_id: 88) }
+  let(:project_collection_type) { Hyrax::CollectionType.create(title: "Project", machine_id: 77) }
+  let(:another_collection_type) { Hyrax::CollectionType.create(title: "Another", machine_id: 99)}
+
+  let(:project_a) { Collection.new(id: 'Project_A', collection_type_gid: project_collection_type.gid )}
+  let(:team_a) { Collection.new(id: 'Team_A', collection_type_gid: team_collection_type.gid )}
+  let(:another) { Collection.new(id: 'Another', collection_type_gid: another_collection_type.gid )}
+
+  let(:scope) { double(current_ability: ability, blacklight_config: CatalogController.blacklight_config) }
+  let(:access) { :deposit }
+  let(:user) { User.create(email: "email@email.com", password: "password", ms_id: "abc123") }
+  let(:ability) { ::Ability.new(user) }
+  let(:nesting_attributes) { double(parents: [], pathnames: [collection.id], ancestors: [], depth: 1) }
+
+  let(:builder) { described_class.new(scope: scope, access: access, collection: collection, nesting_attributes: nesting_attributes, nest_direction: nest_direction) }
+
+  let(:solr_params) { {} }
+
+  before do
+    allow(Hyrax::CollectionType).to receive(:find_by).with(title: "Team").and_return(team_collection_type)
+    allow(Hyrax::CollectionType).to receive(:find_by).with(title: "Project").and_return(project_collection_type)
+  end
+
+  describe '#show_only_other_collections_of_the_same_collection_type' do
+    let(:collection) { project_a }
+    let(:nest_direction) { :as_child }
+    subject { builder }
+
+    it 'should call #show_only_valid_collection_types' do
+      expect(subject).to receive(:show_only_valid_collection_types).with(solr_params)
+      subject.show_only_other_collections_of_the_same_collection_type(solr_params)
+    end
+  end
+
+  describe '#show_only_valid_collection_types' do
+    let(:single_type_as_child) { ["-{!terms f=id}#{collection.id}", "_query_:\"{!field f=collection_type_gid_ssim}#{collection.collection_type_gid}\"", "-_query_:\"{!lucene q.op=OR df=nesting_collection__pathnames_ssim}#{collection.id}\"", "-_query_:\"{!field f=nesting_collection__parent_ids_ssim}#{collection.id}\""] }
+
+    let(:single_type_as_parent) { ["-{!terms f=id}#{collection.id}", "_query_:\"{!field f=collection_type_gid_ssim}#{collection.collection_type_gid}\"", "-_query_:\"{!lucene df=nesting_collection__pathnames_ssim}*#{collection.id}*\""] }
+
+    subject { builder.show_only_valid_collection_types(solr_params) }
+
+    describe 'adding project as subcollection' do
+      let(:collection) { project_a }
+      let(:nest_direction) { :as_parent }
+
+      it 'should build a query for projects and teams' do
+        subject
+        expect(solr_params.fetch(:fq)).to match_array(["-{!terms f=id}#{collection.id}", "(_query_:\"{!field f=collection_type_gid_ssim}#{project_collection_type.gid}\" OR _query_:\"{!field f=collection_type_gid_ssim}#{team_collection_type.gid}\")", "-_query_:\"{!lucene df=nesting_collection__pathnames_ssim}*#{collection.id}*\""])
+      end
+    end
+
+    describe 'adding a team as a parent collection' do
+      let(:collection) { team_a }
+      let(:nest_direction) { :as_child }
+      it 'should build a query for projects and teams' do
+        subject
+        expect(solr_params.fetch(:fq)).to match_array(["-{!terms f=id}#{collection.id}", "(_query_:\"{!field f=collection_type_gid_ssim}#{project_collection_type.gid}\" OR _query_:\"{!field f=collection_type_gid_ssim}#{team_collection_type.gid}\")", "-_query_:\"{!lucene q.op=OR df=nesting_collection__pathnames_ssim}#{collection.id}\"", "-_query_:\"{!field f=nesting_collection__parent_ids_ssim}#{collection.id}\""])
+      end
+    end
+
+    describe 'adding team as subcollection' do
+      let(:collection) { team_a }
+      let(:nest_direction) { :as_parent }
+      it 'should build a query for teams only' do
+        subject
+        expect(solr_params.fetch(:fq)).to match_array(single_type_as_parent)
+      end
+    end
+
+    describe 'adding project as a parent collection' do
+      let(:collection) { project_a }
+      let(:nest_direction) { :as_child }
+      it 'should build a query for projects only' do
+        subject
+        expect(solr_params.fetch(:fq)).to match_array(single_type_as_child)
+      end
+    end
+
+    describe 'adding another collection type as subcollection' do
+      let(:collection) { another }
+      let(:nest_direction) { :as_parent }
+      it 'should build a query for that collection type only' do
+        subject
+        expect(solr_params.fetch(:fq)).to match_array(single_type_as_parent)
+      end
+    end
+
+    describe 'addiing another collection type as a parent collection' do
+      let(:collection) { another }
+      let(:nest_direction) { :as_child }
+      it 'should bulid a query for that collection type only' do
+        subject
+        expect(solr_params.fetch(:fq)).to match_array(single_type_as_child)
+      end
+    end
+  end
+end

--- a/spec/config/permissions_create_service_spec.rb
+++ b/spec/config/permissions_create_service_spec.rb
@@ -1,0 +1,72 @@
+require 'rails_helper'
+
+RSpec.describe Hyrax::Collections::PermissionsCreateService do
+  let(:team_collection_type)    { Hyrax::CollectionType.create(title: "Team", machine_id: 88) }
+  let(:project_collection_type) { Hyrax::CollectionType.create(title: "Project", machine_id: 77) }
+  let(:another_collection_type) { Hyrax::CollectionType.create(title: "Another", machine_id: 99)}
+
+  let(:team_a)    { Collection.new(id: 'Team_A', title: ["Team A"], collection_type_gid: team_collection_type.gid )}
+  let(:project_a) { Collection.new(id: 'Project_A', title: ["Project A"], collection_type_gid: project_collection_type.gid )}
+  let(:another)   { Collection.new(id: 'Another', title: ["Another"], collection_type_gid: another_collection_type.gid )}
+
+  let(:user) { User.create(email: "email@email.com", password: "password", ms_id: "abc123") }
+
+  let(:collections)       { [team_a, project_a, another] }
+  let(:collection_types)  { [team_collection_type, project_collection_type, another_collection_type]}
+
+  describe '#create_default' do
+    let(:access_grants)   { collection.permission_template.access_grants }
+    let(:admin)           { access_grants.find_by(agent_id: "admin") }
+
+    Collection::DEFAULT_GROUP_ROLES.each do |role|
+      let(role.to_sym) { access_grants.find_by(agent_id: "#{collection.id}_#{role}")}
+    end
+
+    before do
+      collection_types.each do |type|
+        allow(Hyrax::CollectionType).to receive(:find_by_gid!).with(type.gid).and_return(type)
+      end
+      collections.each do |collection|
+        Collection::DEFAULT_GROUP_ROLES.each do |role|
+          allow(collection).to receive_message_chain("#{role}_group.name").and_return("#{collection.id}_#{role}")
+        end
+      end
+      allow_any_instance_of(Collection).to receive(:add_depositor_to_managers).and_return(true)
+      described_class.create_default(collection: collection, creating_user: user)
+    end
+
+    context 'user creates a new team' do
+      let(:collection) { team_a }
+
+      it 'assigns admins and collection groups to appropriate access levels' do
+        expect(access_grants.count).to be(4)
+        expect(admin[:access]).to eq(Hyrax::PermissionTemplateAccess::MANAGE)
+        expect(managers[:access]).to eq(Hyrax::PermissionTemplateAccess::MANAGE)
+        expect(depositors[:access]).to eq(Hyrax::PermissionTemplateAccess::DEPOSIT)
+        expect(viewers[:access]).to eq(Hyrax::PermissionTemplateAccess::VIEW)
+      end
+    end
+    context 'user creates a new project' do
+      let(:collection) { project_a }
+
+      it 'assigns admins and collection groups to appropriate access levels' do
+        expect(access_grants.count).to be(4)
+        expect(admin[:access]).to eq(Hyrax::PermissionTemplateAccess::MANAGE)
+        expect(managers[:access]).to eq(Hyrax::PermissionTemplateAccess::MANAGE)
+        expect(depositors[:access]).to eq(Hyrax::PermissionTemplateAccess::DEPOSIT)
+        expect(viewers[:access]).to eq(Hyrax::PermissionTemplateAccess::VIEW)
+      end
+
+    end
+    context 'user creates a new collection that is neither a team or a project' do
+      let(:collection)  { another }
+      let(:user_grant) { access_grants.find_by(agent_id: user.ms_id) }
+
+      it 'creates access grants for the admin group and the collection creator' do
+        expect(access_grants.count).to be(2)
+        expect(admin[:access]).to eq(Hyrax::PermissionTemplateAccess::MANAGE)
+        expect(user_grant[:access]).to eq(Hyrax::PermissionTemplateAccess::MANAGE)
+      end
+    end
+  end
+end

--- a/spec/lib/morphosource/collections/projects_spec.rb
+++ b/spec/lib/morphosource/collections/projects_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+RSpec.describe Morphosource::CollectionTypes::Projects do
+
+  describe 'SETTINGS' do
+
+    it 'provides the correct configuration for projects' do
+      project_collection_type = Hyrax::CollectionType.new(subject::SETTINGS)
+
+      expect(project_collection_type.title).to eq("Project")
+      expect(project_collection_type.description).to eq("Assortment of media and physical object records. Media and physical object records can belong to multiple projects. Multiple users or teams can manage projects.")
+      expect(project_collection_type.machine_id).to eq("project")
+      expect(project_collection_type.nestable).to be(true)
+      expect(project_collection_type.discoverable).to be(true)
+      expect(project_collection_type.sharable).to be(true)
+      expect(project_collection_type.allow_multiple_membership).to be(true)
+      expect(project_collection_type.require_membership).to be(false)
+      expect(project_collection_type.assigns_workflow).to be(false)
+      expect(project_collection_type.assigns_visibility).to be(true)
+      expect(project_collection_type.share_applies_to_new_works).to be(true)
+      expect(project_collection_type.brandable).to be(true)
+      expect(project_collection_type.badge_color).to eq("#003880")
+    end
+  end
+end

--- a/spec/lib/morphosource/collections/teams_spec.rb
+++ b/spec/lib/morphosource/collections/teams_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+RSpec.describe Morphosource::CollectionTypes::Teams do
+
+  describe 'SETTINGS' do
+
+    it 'provides the correct configuration for teams' do
+      team_collection_type = Hyrax::CollectionType.new(subject::SETTINGS)
+
+      expect(team_collection_type.title).to eq("Team")
+      expect(team_collection_type.description).to eq("Group of users belonging to the same institution, organization, department, collection, or lab. Teams can manage projects collectively.")
+      expect(team_collection_type.machine_id).to eq("team")
+      expect(team_collection_type.nestable).to be(true)
+      expect(team_collection_type.discoverable).to be(true)
+      expect(team_collection_type.sharable).to be(true)
+      expect(team_collection_type.allow_multiple_membership).to be(true)
+      expect(team_collection_type.require_membership).to be(false)
+      expect(team_collection_type.assigns_workflow).to be(false)
+      expect(team_collection_type.assigns_visibility).to be(true)
+      expect(team_collection_type.share_applies_to_new_works).to be(true)
+      expect(team_collection_type.brandable).to be(true)
+      expect(team_collection_type.badge_color).to eq("#FF861F")
+    end
+  end
+end

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+RSpec.describe Collection, type: :model do
+
+  let(:team_collection_type) { Hyrax::CollectionType.create(title: "Team", machine_id: 88) }
+  let(:project_collection_type) { Hyrax::CollectionType.create(title: "Project", machine_id: 77) }
+  let(:another_collection_type) { Hyrax::CollectionType.create(title: "Another", machine_id: 99) }
+  let(:user) { User.create(email: "email@email.com", password: "password", ms_id: "abc123") }
+
+  describe '#create_collection_groups' do
+    before do
+      allow(User).to receive(:find_by).with(ms_id: user.ms_id).and_return(user)
+    end
+    it 'is called on create' do
+      @collection = Collection.new(title: ['Team_A'], collection_type_gid: team_collection_type.gid, depositor: user.ms_id)
+      expect(@collection).to receive(:create_collection_groups)
+      @collection.save
+    end
+
+    describe 'a user creates a new team' do
+      it 'creates manager, depositor, and viewer groups' do
+        expect{ Collection.create(title: ['Team_B'], collection_type_gid: team_collection_type.gid, depositor: user.ms_id)
+        }.to change{ Role.count }.by(3)
+      end
+      it 'assigns them names with the collection id' do
+        @collection = Collection.create(title: ['Team_C'], collection_type_gid: team_collection_type.gid, depositor: user.ms_id)
+
+        group_names = Role.all.map(&:name)
+        Collection::DEFAULT_GROUP_ROLES.each do |role|
+          expect(group_names).to include("#{@collection.id}_#{role}")
+        end
+      end
+    end
+
+    describe 'a user creates a new project' do
+      it 'creates manager, depositor, and viewer groups' do
+        expect{ Collection.create(title: ['Project_A'], collection_type_gid: project_collection_type.gid, depositor: user.ms_id)
+        }.to change{ Role.count }.by(3)
+      end
+      it 'assigns them names with the collection id' do
+        @collection = Collection.create(title: ['Team_C'], collection_type_gid: project_collection_type.gid, depositor: user.ms_id)
+
+        group_names = Role.all.map(&:name)
+        Collection::DEFAULT_GROUP_ROLES.each do |role|
+          expect(group_names).to include("#{@collection.id}_#{role}")
+        end
+      end
+    end
+
+    describe 'a user creates another type of collection' do
+      it 'does not create collection groups' do
+        expect{ Collection.create(title: ['Another'], collection_type_gid: another_collection_type.gid, depositor: user.ms_id)
+        }.to_not change{ Role.count }
+      end
+    end
+  end
+end

--- a/spec/tasks/morphosource_spec.rb
+++ b/spec/tasks/morphosource_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+require 'rake'
+
+  describe "morphosource:create_collection_types", type: :task do
+
+    before do
+      Rails.application.load_tasks if Rake::Task.tasks.empty?
+    end
+
+    it "preloads the Rails environment" do
+      expect(Rake::Task['morphosource:create_collection_types'].prerequisites).to include "environment"
+    end
+
+    it "creates team and project collection types" do
+      Rake::Task['morphosource:create_collection_types'].invoke
+      expect(Hyrax::CollectionType.count).to eq(2)
+
+      types = Hyrax::CollectionType.all
+      team = types.find{|t| t[:title] == "Team"}
+      project = types.find{|t| t[:title] == "Project"}
+
+      expect(team.title).to eq("Team")
+      expect(team.description).to eq("Group of users belonging to the same institution, organization, department, collection, or lab. Teams can manage projects collectively.")
+      expect(team.machine_id).to eq("team")
+      expect(team.nestable).to be(true)
+      expect(team.discoverable).to be(true)
+      expect(team.sharable).to be(true)
+      expect(team.allow_multiple_membership).to be(true)
+      expect(team.require_membership).to be(false)
+      expect(team.assigns_workflow).to be(false)
+      expect(team.assigns_visibility).to be(true)
+      expect(team.share_applies_to_new_works).to be(true)
+      expect(team.brandable).to be(true)
+      expect(team.badge_color).to eq("#FF861F")
+
+      expect(project.title).to eq("Project")
+      expect(project.description).to eq("Assortment of media and physical object records. Media and physical object records can belong to multiple projects. Multiple users or teams can manage projects.")
+      expect(project.machine_id).to eq("project")
+      expect(project.nestable).to be(true)
+      expect(project.discoverable).to be(true)
+      expect(project.sharable).to be(true)
+      expect(project.allow_multiple_membership).to be(true)
+      expect(project.require_membership).to be(false)
+      expect(project.assigns_workflow).to be(false)
+      expect(project.assigns_visibility).to be(true)
+      expect(project.share_applies_to_new_works).to be(true)
+      expect(project.brandable).to be(true)
+      expect(project.badge_color).to eq("#003880")
+    end
+  end


### PR DESCRIPTION
- Establishes Settings for Project and Team Collection Types
- Creates a rake task for setting up Team and Project Collection Types (morphosource:create_collection_types)
- Creates Manager/Depositor/Viewer groups upon Project or Team creation
- Assigns those groups to appropriate access grants
- Allows Projects to be nested within Teams
- Returns results for both projects and teams (when appropriate) when a user wants to select a collection to associate with another