### PR TITLE
MR-626: Deleting a Team or Project also deletes its default user groups

### DIFF
--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -6,6 +6,7 @@ class Collection < ActiveFedora::Base
   self.indexer = Hyrax::CollectionWithBasicMetadataIndexer
 
   after_create :create_collection_groups, if: :type_assigns_groups?
+  after_destroy :destroy_default_groups, if: :type_assigns_groups?
 
   DEFAULT_GROUP_ROLES = ["managers", "depositors", "viewers"]
 
@@ -36,7 +37,7 @@ class Collection < ActiveFedora::Base
   end
 
   def user_groups
-    [ managers_group, depositors_group, viewers_group ]
+    [managers_group, depositors_group, viewers_group]
   end
 
   def group_members
@@ -57,5 +58,9 @@ class Collection < ActiveFedora::Base
       user = User.find_by(ms_id: depositor)
       managers_group.users << user
       managers_group.save
+    end
+
+    def destroy_default_groups
+      user_groups.compact.each(&:destroy)
     end
 end

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -85,4 +85,28 @@ RSpec.describe Collection, type: :model do
       end
     end
   end
+
+  describe '#destroy_default_groups' do
+    context 'the deleted collection is not a team or project' do
+      let(:another) { Collection.create(title: ['Another'], collection_type_gid: another_collection_type.gid, depositor: user.ms_id) }
+
+      it 'does not call #destroy_default_groups' do
+        expect(another).not_to receive(:destroy_default_groups)
+        another.destroy
+      end
+    end
+
+    context 'the deleted collection is a team or project' do
+      let!(:team) { Collection.create(title: ['Team_A'], collection_type_gid: team_collection_type.gid, depositor: user.ms_id) }
+
+      it 'calls #destroy_default_groups' do
+        expect(team).to receive(:destroy_default_groups)
+        team.destroy
+      end
+
+      it 'destroys all of the default user groups when a team or project is destroyed' do
+        expect { team.destroy }.to change { Role.count }.by(-3)
+      end
+    end
+  end
 end


### PR DESCRIPTION
- Hyrax already removes access grants & permission template when the collection is deleted. 