### PR TITLE
MR-656: Link teams and organizations

### DIFF
--- a/app/controllers/morphosource/dashboard/linked_teams_controller.rb
+++ b/app/controllers/morphosource/dashboard/linked_teams_controller.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Morphosource
+  module Dashboard
+    # Allows admins to link teams to organizations from the collection dashboard view
+    class LinkedTeamsController < ApplicationController
+      before_action :find_team_and_organization
+
+      def link_organization
+        return unless current_user.admin?
+
+        clear_organization
+        add_organization
+        redirect_back(fallback_location: hyrax.edit_dashboard_collection_path(params[:id], locale: 'en', anchor: 'organization'))
+      end
+
+      private
+
+        def add_organization
+          @organization.team_id = [params[:id]]
+          @organization.save
+        end
+
+        def clear_organization
+          return unless @team.organization
+          @old_org = @team.organization
+          @old_org.team_id = []
+          @old_org.save
+        end
+
+        def find_team_and_organization
+          @organization = Organization.find(params[:collection][:organization_id])
+          @team = Collection.find(params[:id])
+        end
+    end
+  end
+end

--- a/app/helpers/morphosource/linked_teams_helper.rb
+++ b/app/helpers/morphosource/linked_teams_helper.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Morphosource
+  # Helper for linking teams to organizations
+  module LinkedTeamsHelper
+    def unlinked_organizations
+      orgs = Organization.all.select { |o| o.team_id.blank? }
+      orgs.collect { |o| [o.title.first, o.id] }
+    end
+  end
+end

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -7,6 +7,8 @@ class Collection < ActiveFedora::Base
   include Hyrax::BasicMetadata
   self.indexer = Hyrax::CollectionWithBasicMetadataIndexer
 
+  attr_accessor :organization_id
+
   after_destroy :destroy_default_groups, if: :type_assigns_groups?
 
   DEFAULT_GROUP_ROLES = %w[managers depositors viewers].freeze
@@ -52,6 +54,10 @@ class Collection < ActiveFedora::Base
 
   def parent?
     !member_of_collections.empty?
+  end
+
+  def organization
+    Organization.where(team_id: id).first
   end
 
   # Create manager/depositor/viewer roles for each Team/Project collection

--- a/app/models/concerns/morphosource/organization_metadata.rb
+++ b/app/models/concerns/morphosource/organization_metadata.rb
@@ -2,36 +2,40 @@ module Morphosource
   # Module to define core (non-modality specific) metadata properties for
   # media works
   module OrganizationMetadata
-	extend ActiveSupport::Concern
+  extend ActiveSupport::Concern
 
-		included do
-		  property :institution_code, predicate: ::RDF::Vocab::DWC.organizationID do |index|
-		  	index.as :stored_searchable
-		  end
+    included do
+      property :institution_code, predicate: ::RDF::Vocab::DWC.organizationID do |index|
+        index.as :stored_searchable
+      end
 
-		  property :address, predicate: ::RDF::Vocab::DWC.locality do |index|
-		  	index.as :stored_searchable
-		  end
+      property :address, predicate: ::RDF::Vocab::DWC.locality do |index|
+        index.as :stored_searchable
+      end
 
-		  property :city, predicate: ::RDF::Vocab::DWC.municipality do |index|
-		  	index.as :stored_searchable
-		  end
+      property :city, predicate: ::RDF::Vocab::DWC.municipality do |index|
+        index.as :stored_searchable
+      end
 
-		  property :state_province, predicate: ::RDF::Vocab::DWC.stateProvince do |index|
-		  	index.as :stored_searchable
-		  end
+      property :state_province, predicate: ::RDF::Vocab::DWC.stateProvince do |index|
+        index.as :stored_searchable
+      end
 
-		  property :country, predicate: ::RDF::Vocab::DWC.country do |index|
-		  	index.as :stored_searchable, :facetable
-		  end
+      property :country, predicate: ::RDF::Vocab::DWC.country do |index|
+        index.as :stored_searchable, :facetable
+      end
 
-		  property :institution_name, predicate: ::RDF::Vocab::DWC.institutionName do |index|
-		  	index.as :stored_searchable, :facetable
-		  end
+      property :institution_name, predicate: ::RDF::Vocab::DWC.institutionName do |index|
+        index.as :stored_searchable, :facetable
+      end
 
-		  property :collection_code, predicate: ::RDF::Vocab::DWC.collectionCode do |index|
-		  	index.as :stored_searchable, :facetable
-		  end
-	  end
+      property :collection_code, predicate: ::RDF::Vocab::DWC.collectionCode do |index|
+        index.as :stored_searchable, :facetable
+      end
+
+      property :team_id, predicate: ::RDF::URI.new("https://www.morphosource.org/terms/team") do |index|
+        index.as :stored_searchable
+      end
+    end
   end
 end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Organization < Morphosource::Works::Base
   include ::Hyrax::WorkBehavior
   validates_with Morphosource::ParentChildValidator
@@ -13,4 +15,32 @@ class Organization < Morphosource::Works::Base
   # This must be included at the end, because it finalizes the metadata
   # schema (by adding accepts_nested_attributes)
   include ::Hyrax::BasicMetadata
+
+  def specimens
+    ActiveFedora::Base.find(member_ids).select { |m| m.class == BiologicalSpecimen }
+  end
+
+  # Specimens that belong to the organization, but are not part of the liked team's items.
+  def outside_specimens
+    outside_team(specimens)
+  end
+
+  def media
+    descendants.select { |d| d.class == Media }
+  end
+
+  # Media that belong to specimens owned by the organization, but are not part of the liked team's items.
+  def outside_media
+    outside_team(media)
+  end
+
+  def team
+    Collection.find(team_id.first)
+  end
+
+  private
+
+    def outside_team(works)
+      works.select { |w| !w.member_of_collections.include? team }
+    end
 end

--- a/app/presenters/hyrax/organization_presenter.rb
+++ b/app/presenters/hyrax/organization_presenter.rb
@@ -4,6 +4,6 @@ module Hyrax
   class OrganizationPresenter < Hyrax::WorkShowPresenter
     include Morphosource::PresenterMethods
 
-    delegate :institution_code, :address, :city, :state_province, :country, to: :solr_document
+    delegate :institution_code, :address, :city, :state_province, :country, :team_id, to: :solr_document
   end
 end

--- a/app/views/hyrax/dashboard/collections/_ms_linked_organization.html.erb
+++ b/app/views/hyrax/dashboard/collections/_ms_linked_organization.html.erb
@@ -1,0 +1,37 @@
+<div style="margin-top: 40px; margin-bottom: 40px; margin-left: 80px;">
+  <% if @current_user.admin? %>
+  <h3 style="margin-left: -80px;">Link an Organization:</h3>
+    <div class="form-add-organization-wrapper">
+      <div class="form-inline add-sharing-form sharing-row-form">
+        <%= simple_form_for @collection,
+            url: main_app.dashboard_collection_link_organization_path,
+            method: 'post',
+            html: { id: 'add-organization-form' } do |f| %>
+          <%= f.select(:organization_id, unlinked_organizations, { prompt: "Select an organization", class: 'form-control'})  %>
+          <%= submit_tag 'Add', class: 'btn btn-info' %>
+        <% end %>
+      </div>
+    </div>
+  <% end %>
+<% if @collection.organization %>
+  <% @organization = @collection.organization %>
+    <h3 style="margin-left: -80px;">Organization:</h3>
+    <p><strong>Title: </strong><%= @organization.title.first %></p>
+    <p><strong>Institution Code: </strong><%= @organization.institution_code.first %></p>
+    <p><strong>Description: </strong><%= @organization.description.first %></p>
+    <p><strong>Address: </strong><%= @organization.address.first %></p>
+    <p><strong>City: </strong><%= @organization.city.first %></p>
+    <p><strong>State/Province: </strong><%= @organization.state_province.first %></p>
+    <p><strong>Country: </strong><%= @organization.country.first %></p>
+    <p><strong>Institution Name: </strong><%= @organization.institution_name.first %></p>
+    <p><strong>Collection Code: </strong><%= @organization.collection_code.first %></p>
+    <h3 style="margin-left: -80px;">Organization-Linked Works:</h3>
+    <p><strong>Specimens: </strong><%= @organization.specimens.count %></p>
+    <p><strong>Specimens Not Owned By Team: </strong><%= @organization.outside_specimens.count %></p>
+    <p><strong>Media: </strong><%= @organization.media.count %></p>
+    <p><strong>Media Not Owned By Team: </strong><%= @organization.outside_media.count %></p>
+<% else %>
+  <h3 style="margin-left: -80px;">Organization:</h3>
+  <h4>No Associated Organization</h4>
+<% end %>
+</div>

--- a/app/views/hyrax/dashboard/collections/show.html.erb
+++ b/app/views/hyrax/dashboard/collections/show.html.erb
@@ -1,0 +1,104 @@
+<% provide :page_title, construct_page_title(@presenter.title) %>
+
+<% provide :page_header do %>
+  <h1><span class="fa fa-file" aria-hidden="true"></span> <%= t('.header') %></h1>
+<% end %>
+
+<div class="collections-wrapper">
+  <section class="panel panel-default collections-panel-wrapper admin-show-page">
+    <div class="panel-heading">
+      <%= render 'collection_title', presenter: @presenter %>
+    </div>
+
+    <div class="panel-body">
+      <section>
+        <div itemscope itemtype="http://schema.org/CollectionPage" class="row collection">
+          <div class="col-sm-3 text-center">
+              <%= render 'hyrax/collections/media_display', presenter: @presenter %>
+              <%= link_to t('.public_view_label'), collection_path(id: @presenter.id) %>
+          </div>
+          <div class="col-sm-9 collection-description-wrapper">
+            <!-- Parent Collection(s) -->
+            <% if @presenter.collection_type_is_nestable? && @presenter.total_parent_collections > 0 %>
+                <h4><%= t('.parent_collection_header') %> (<%= @presenter.total_parent_collections %>)</h4>
+                <section id="parent-collections-wrapper" class="parent-collections-wrapper">
+                  <%= render 'hyrax/dashboard/collections/show_parent_collections', presenter: @presenter %>
+                </section>
+            <% end %>
+
+            <!-- Collection Description(s) -->
+            <section>
+              <%= render 'hyrax/collections/collection_description', presenter: @presenter %>
+            </section>
+
+            <% unless has_collection_search_parameters? %>
+              <%= render 'show_descriptions' %>
+            <% end %>
+          </div>
+        </div>
+      </section>
+
+      <!-- Search results label -->
+
+      <% if @members_count > 0 || @presenter.subcollection_count > 0 %>
+          <div class="hyc-blacklight hyc-bl-title">
+            <h2>
+              <% if has_collection_search_parameters? %>
+                  <%= t('hyrax.dashboard.collections.show.search_results') %>
+              <% end %>
+            </h2>
+          </div>
+      <% end %>
+
+      <!-- Search bar -->
+      <section class="collections-search-wrapper">
+        <div class="row">
+          <div class="col-sm-8">
+            <%# TODO: leaving this as it was causes rerouting to the public show page. needs work %>
+            <%= render 'hyrax/collections/search_form', presenter: @presenter, url: hyrax.dashboard_collection_path(@presenter.id) %>
+          </div>
+        </div>
+      </section>
+
+      <!-- Subcollections -->
+      <% if @presenter.collection_type_is_nestable? %>
+        <section id="sub-collections-wrapper" class="sub-collections-wrapper">
+          <h4><%= t('.subcollection_count') %> (<%= @subcollection_count %>)</h4>
+          <div class="row">
+            <div class="col-md-7">
+              <%= render 'subcollection_list', id: @presenter.id, collection: @subcollection_docs %>
+            </div>
+            <% unless has_collection_search_parameters? %>
+              <div class="col-md-5">
+                <%= render 'show_subcollection_actions', presenter: @presenter %>
+              </div>
+            <% end %>
+          </div>
+        </section>
+      <% end %>
+
+      <!-- Works -->
+      <section class="works-wrapper">
+        <h4><%= t('.item_count') %> (<%= @members_count %>)</h4>
+        <% unless has_collection_search_parameters? %>
+          <%= render 'show_add_items_actions', presenter: @presenter %>
+        <% end %>
+
+        <%= render 'sort_and_per_page', collection: @presenter %>
+        <%= render_document_index @member_docs %>
+        <%= render 'hyrax/collections/paginate' %>
+      </section>
+
+    </div><!-- /panel-body -->
+  </section><!-- /collections-panel-wrapper -->
+</div><!-- /collections-wrapper -->
+
+<% if @presenter.collection_type_is_nestable? && !has_collection_search_parameters? %>
+  <%= render 'hyrax/my/collections/modal_add_to_collection', source: 'show' %>
+  <%= render 'hyrax/my/collections/modal_add_subcollection', id: @presenter.id, source: 'show' %>
+  <%= render 'hyrax/dashboard/collections/modal_parent_collection_remove_deny', source: 'show' %>
+<% end %>
+
+<% unless has_collection_search_parameters? %>
+  <%= render '/shared/select_work_type_modal', create_work_presenter: @presenter.create_work_presenter if @presenter.draw_select_work_modal? %>
+<% end %>

--- a/app/views/hyrax/dashboard/collections/show.html.erb
+++ b/app/views/hyrax/dashboard/collections/show.html.erb
@@ -5,7 +5,7 @@
     <span class="fa fa-file" aria-hidden="true"></span>
     <% if @collection.team? %>
       Team
-    <% elsif @collection.project? %> 
+    <% elsif @collection.project? %>
       Project
     <% else %>
       <%= t('.header') %>
@@ -40,13 +40,21 @@
               <%= render 'hyrax/collections/collection_description', presenter: @presenter %>
             </section>
 
-            <!-- Linked Organization -->
-            <section>
-              <%= render 'ms_linked_organization', presenter: @presenter, collection: @collection %>
-            <section>
+            <!-- Linked Organization if @collection is a team -->
+            <% if @collection.team? %>
+              <section>
+                <%= render 'ms_linked_organization', presenter: @presenter, collection: @collection %>
+              <section>
+            <% end %>
 
             <% unless has_collection_search_parameters? %>
-              <h3>Team: </h3>
+              <% if @collection.team? %>
+                <h3>Team: </h3>
+              <% elsif @collection.project? %>
+                <h4>Project: </h4>
+              <% else %>
+                <h4>Collection: </h4>
+              <% end %>
               <%= render 'show_descriptions' %>
             <% end %>
           </div>

--- a/app/views/hyrax/dashboard/collections/show.html.erb
+++ b/app/views/hyrax/dashboard/collections/show.html.erb
@@ -1,7 +1,16 @@
 <% provide :page_title, construct_page_title(@presenter.title) %>
 
 <% provide :page_header do %>
-  <h1><span class="fa fa-file" aria-hidden="true"></span> <%= t('.header') %></h1>
+  <h1>
+    <span class="fa fa-file" aria-hidden="true"></span>
+    <% if @collection.team? %>
+      Team
+    <% elsif @collection.project? %> 
+      Project
+    <% else %>
+      <%= t('.header') %>
+    <% end %>
+  </h1>
 <% end %>
 
 <div class="collections-wrapper">
@@ -31,7 +40,13 @@
               <%= render 'hyrax/collections/collection_description', presenter: @presenter %>
             </section>
 
+            <!-- Linked Organization -->
+            <section>
+              <%= render 'ms_linked_organization', presenter: @presenter, collection: @collection %>
+            <section>
+
             <% unless has_collection_search_parameters? %>
+              <h3>Team: </h3>
               <%= render 'show_descriptions' %>
             <% end %>
           </div>

--- a/config/initializers/morphosource/collection_presenter.rb
+++ b/config/initializers/morphosource/collection_presenter.rb
@@ -1,0 +1,3 @@
+Hyrax::CollectionPresenter.class_eval do
+  include Morphosource::LinkedTeamsHelper
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -169,4 +169,10 @@ Rails.application.routes.draw do
   # Add users to auto-generated collection groups
   post 'dashboard/collections/:id/update_collection_groups', action: :update_collection_groups, controller: :collection_roles, as: 'update_collection_groups'
 
+  # Link organization to team
+  scope module: :morphosource do
+    scope module: :dashboard do
+      post 'dashboard/collections/:id/organizations', action: :link_organization, controller: :linked_teams, as: 'dashboard_collection_link_organization'
+    end
+  end
 end

--- a/lib/morphosource/works/base.rb
+++ b/lib/morphosource/works/base.rb
@@ -9,15 +9,31 @@ module Morphosource
       self.work_requires_files = false
 
       def self.valid_parent_concerns
-        concerns = []
-        Morphosource::Works::Base.descendants.each do |model|
+        concerns = Morphosource::Works::Base.descendants
+        concerns.each_with_object([]) do |model, parents|
           if model.valid_child_concerns.include? self
-            concerns << model
+            parents << model
           end
         end
-        concerns
       end
 
+      def descendants
+        @descendants = members
+        get_all_children(@descendants)
+        @descendants.flatten.uniq
+      end
+
+      private
+
+      def get_all_children(objects)
+        objects.flatten.each do |object|
+          unless object.member_ids.blank?
+            children = object.members
+            @descendants << children
+            get_all_children(children)
+          end
+        end
+      end
     end
   end
 end

--- a/spec/controllers/morphosource/dashboard/linked_teams_controller_spec.rb
+++ b/spec/controllers/morphosource/dashboard/linked_teams_controller_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Morphosource::Dashboard::LinkedTeamsController, type: :controller do
+  let(:org1)                  { Organization.new(id: 'org1', title: ['title'], institution_code: ['ABC'])}
+  let(:org2)                  { Organization.create( id: 'org2', title: ['title'], institution_code: ['DEF'], team_id: [team.id])}
+  let(:team_collection_type)  { Hyrax::CollectionType.create(title: 'Team', machine_id: 88) }
+  let(:team)                  { Collection.new(id: 'teamid', title: ['Team_A'], collection_type_gid: team_collection_type.gid, depositor: 'abcdef') }
+  let(:admin)                 { User.create(id: 'admin', email: 'email@email.com', password: 'password')}
+  let(:params)                { { id: team.id, collection: { organization_id: org1.id } } }
+
+  before do
+    allow(Organization).to receive(:find).with(org1.id).and_return(org1)
+    allow(Organization).to receive(:find).with(org2.id).and_return(org2)
+    allow(Collection).to receive(:find).with(team.id).and_return(team)
+
+    sign_in admin
+  end
+
+
+  describe '#link_organization' do
+    context 'the current user is not an admin' do
+      it 'should not call #clear_organization or #add_organization' do
+        expect(subject).to_not receive(:clear_organization)
+        expect(subject).to_not receive(:add_organization)
+        post :link_organization, params: params
+      end
+    end
+    context 'the current user is an admin' do
+      before do
+        allow(subject.current_user).to receive(:admin?).and_return(true)
+        request.env["HTTP_REFERER"] = "original_page"
+        post :link_organization, params: params
+      end
+      context 'the team already has a linked organization' do
+        before do
+          allow(Organization).to receive(:where).with(team_id: team.id).and_return([org2])
+        end
+        it 'clears the old organization' do
+          expect(org2.reload.team_id).to eq([])
+        end
+        it 'adds the new organization' do
+          expect(org1.team_id).to eq([team.id])
+        end
+        it 'redirects back to the collection dashboard page' do
+          expect(response).to redirect_to("original_page")
+        end
+      end
+      context 'the team does not already have a linked organization' do
+        it 'adds the new organization' do
+          expect(org1.team_id).to eq([team.id])
+        end
+        it 'redirects back to the collection dashboard page' do
+          expect(response).to redirect_to("original_page")
+        end
+      end
+    end
+  end
+end

--- a/spec/helpers/morphosource/collection_roles_helper_spec.rb
+++ b/spec/helpers/morphosource/collection_roles_helper_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Morphosource::CartItemHelper, type: :helper do
+RSpec.describe Morphosource::CollectionRolesHelper, type: :helper do
 
   before do
     helper.instance_variable_set(:@virtual_path, 'hyrax.dashboard.collections.form_share')

--- a/spec/helpers/morphosource/linked_teams_helper_spec.rb
+++ b/spec/helpers/morphosource/linked_teams_helper_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Morphosource::LinkedTeamsHelper, type: :helper do
+  describe '#unlinked_organizations' do
+    let!(:org1) { Organization.create(title: ['org1']) }
+    let!(:org2) { Organization.create(title: ['org2']) }
+    let!(:org3) { Organization.create(title: ['org3'], team_id: ['1']) }
+    let!(:org4) { Organization.create(title: ['org4'], team_id: ['2']) }
+    let!(:org5) { Organization.create(title: ['org5'], team_id: ['3']) }
+
+    it 'returns only organizations that are not linked to a team' do
+      expect(helper.unlinked_organizations).to match_array([[org1.title.first, org1.id], [org2.title.first, org2.id]])
+    end
+  end
+end

--- a/spec/lib/morphosource/works/base_spec.rb
+++ b/spec/lib/morphosource/works/base_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Morphosource::Works::Base do
+  let(:organization)    { Organization.new(title: ['organization title']) }
+  let(:specimen1)       { BiologicalSpecimen.new(title: ['title'], vouchered: [true]) }
+  let(:specimen2)       { BiologicalSpecimen.new(title: ['title'], vouchered: [false]) }
+  let(:media1)          { Media.new(title: ['title']) }
+  let(:media2)          { Media.new(title: ['title']) }
+  let(:media3)          { Media.new(title: ['title']) }
+  let(:file_set1)       { FileSet.new }
+  let(:file_set2)       { FileSet.new }
+  let(:file_set3)       { FileSet.new }
+  let(:imagingEvent)    { ImagingEvent.new(title: ['title']) }
+  let(:imagingEvent2)   { ImagingEvent.new(title: ['title']) }
+  let(:processingEvent) { ProcessingEvent.new(title: ['title']) }
+  let(:attachment)      { Attachment.new(title: ['title']) }
+  let(:works)           { [organization, specimen1, specimen2, media1, media2, media3, imagingEvent, imagingEvent2, processingEvent, attachment, file_set1, file_set2, file_set3] }
+
+  describe '#descendants' do
+    let(:org_desc)      { works - [organization] }
+    let(:spec1_desc)    { [imagingEvent, media1, file_set1, processingEvent, media2, file_set2] }
+    let(:spec2_desc)    { [imagingEvent2, media3, file_set3] }
+
+    before do
+      organization.ordered_members << specimen1 << specimen2 << attachment
+      specimen1.ordered_members << imagingEvent
+      imagingEvent.ordered_members << media1
+      media1.ordered_members << processingEvent << file_set1
+      processingEvent.ordered_members << media2
+      media2.ordered_members << file_set2
+      specimen2.ordered_members << imagingEvent2
+      imagingEvent2.ordered_members << media3
+      media3.ordered_members << file_set3
+      works.each(&:save)
+    end
+
+    it 'finds all children (works and filesets) of a work' do
+      expect(organization.descendants).to match_array(org_desc)
+      expect(specimen1.descendants).to match_array(spec1_desc)
+      expect(specimen2.descendants).to match_array(spec2_desc)
+    end
+  end
+end

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -16,6 +16,16 @@ RSpec.describe Collection, type: :model do
     allow(User).to receive(:find_by).with(ms_id: user.ms_id).and_return(user)
   end
 
+  describe '#organization' do
+    let!(:org1)  { Organization.create(title: ['title'], team_id: [team.id]) }
+    let!(:org2)  { Organization.create(title: ['title'], team_id: []) }
+    let!(:org3)  { Organization.create(title: ['title'], team_id: []) }
+
+    it 'returns the organization linked to the team' do
+      expect(team.organization).to eq(org1)
+    end
+  end
+
   describe '#create_collection_groups' do
 
     it 'creates manager, depositor, and viewer groups' do

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 # Generated via
-#  `rails generate hyrax:work Organization`
+# `rails generate hyrax:work Organization`
 require 'rails_helper'
 
 RSpec.describe Organization do
@@ -30,7 +32,8 @@ RSpec.describe Organization do
         address: ['Central Park West'],
         city: ['New York City'],
         state_province: ['New York'],
-        country: ['United States']
+        country: ['United States'],
+        team_id: ['123']
       })
     }
 
@@ -62,6 +65,10 @@ RSpec.describe Organization do
       expect(subject.country.first).to eq('United States')
     end
 
+    it "creates with correct team id" do
+      expect(subject.team_id.first).to eq('123')
+    end
+
     describe "valid work relationships" do
 
       it "has no valid parents" do
@@ -71,9 +78,84 @@ RSpec.describe Organization do
       it "has Device, BiologicalSpecimen, CulturalHeritageObject, and Attachment as valid children" do
         expect(subject.valid_child_concerns).to match_array([Device, BiologicalSpecimen, CulturalHeritageObject, Attachment])
       end
-
     end
 
-  end
+    describe 'team-related instance methods' do
+      let(:team_collection_type)  { Hyrax::CollectionType.create(title: 'Team', machine_id: 88) }
+      let(:team)                  { Collection.create(id: 'teamid', title: ['Team'], collection_type_gid: team_collection_type.gid, depositor: 'abcdef') }
 
+      let(:specimen1)             { BiologicalSpecimen.create(title: ['title'], vouchered: [true]) }
+      let(:specimen2)             { BiologicalSpecimen.create(title: ['title'], vouchered: [false]) }
+      let(:attachment)            { Attachment.create(title: ['title']) }
+
+      before do
+        subject.team_id = [team.id]
+        subject.save
+        allow(Collection).to receive(:find).with(team.id).and_return(team)
+      end
+
+      describe '#team' do
+        it 'returns the linked team' do
+          expect(subject.team).to eq(team)
+        end
+      end
+
+      describe '#specimens, #outside_specimens' do
+        before do
+          subject.ordered_members << specimen1 << specimen2 << attachment
+          subject.save
+          team.add_member_objects [specimen1.id]
+          team.save
+        end
+
+        it '#specimens returns child specimens' do
+          expect(subject.specimens).to match_array([specimen1, specimen2])
+        end
+
+        it '#outside_specimens returns specimens not owned by team' do
+          expect(subject.outside_specimens).to match_array([specimen2])
+        end
+      end
+
+      describe '#media, #outside_media' do
+        let(:media1)          { Media.create(title: ['title']) }
+        let(:media2)          { Media.create(title: ['title']) }
+        let(:media3)          { Media.create(title: ['title']) }
+        let(:imagingEvent)    { ImagingEvent.create(title: ['title']) }
+        let(:imagingEvent2)   { ImagingEvent.create(title: ['title']) }
+        let(:processingEvent) { ProcessingEvent.new(title: ['title']) }
+        let(:attachment)      { Attachment.create(title: ['title']) }
+
+        before do
+          subject.ordered_members << specimen1 << specimen2 << attachment
+          subject.save
+          specimen1.ordered_members << imagingEvent
+          specimen1.save
+          imagingEvent.ordered_members << media1
+          imagingEvent.save
+          media1.ordered_members << processingEvent
+          media1.save
+          processingEvent.ordered_members << media2
+          processingEvent.save
+
+          specimen2.ordered_members << imagingEvent2
+          specimen2.save
+          imagingEvent2.ordered_members << media3
+          imagingEvent2.save
+
+          team.add_member_objects [media3.id]
+          team.save
+          [media1, media2, media3].each(&:reload)
+        end
+
+        it '#media returns all descendant media' do
+          expect(subject.media).to match_array([media1, media2, media3])
+        end
+
+        it '#outside_media returns specimens not owned by team' do
+          expect(subject.outside_media).to match_array([media1, media2])
+        end
+      end
+    end
+  end
 end

--- a/spec/routing/linked_teams_routing_spec.rb
+++ b/spec/routing/linked_teams_routing_spec.rb
@@ -1,0 +1,8 @@
+require 'rails_helper'
+
+RSpec.describe 'linked teams routing', type: :routing do
+  it 'has a route to link teams and organizations' do
+    route = { controller: 'morphosource/dashboard/linked_teams', action: "link_organization", id: ':id' }
+    expect(:post => 'dashboard/collections/:id/organizations').to route_to(route)
+  end
+end


### PR DESCRIPTION
- Admins now have access to a select box on the dashboard collection page for teams that selects an organization to link to the team.
- Select only shows organizations not currently linked to a team.
- When an organization is linked, its metadata is displayed on the dashboard collection page, as well as stats for total number of specimens and media belonging and not belonging to the team.
- Adds a method to Morphosource::Works::Base for recursively getting all descendant works/filesets for a work