### PR TITLE
Update iiif_manifest to provide no multi-fileset manifests + deleting filesets now sets new representative if appropriate

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/MorphoSource/iiif_manifest.git
-  revision: c846a1cbbcb7b68ff83c57e7c7c8902a0158c7dd
+  revision: 65c76544c439d87f5613b90c1f679adfc864ce74
   branch: morphosource
   specs:
     iiif_manifest (0.5.0)
@@ -189,7 +189,7 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     commonjs (0.2.7)
-    concurrent-ruby (1.1.5)
+    concurrent-ruby (1.1.6)
     connection_pool (2.2.2)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
@@ -425,7 +425,7 @@ GEM
       signet
       simple_form (~> 3.2, <= 3.5.0)
       tinymce-rails (~> 4.1)
-    i18n (1.7.0)
+    i18n (1.8.2)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
     io-like (0.3.0)
@@ -541,7 +541,7 @@ GEM
     mini_magick (4.9.5)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
-    minitest (5.12.2)
+    minitest (5.14.0)
     mono_logger (1.1.0)
     multi_json (1.13.1)
     multi_xml (0.6.0)
@@ -866,7 +866,7 @@ GEM
       actionpack (>= 3.1)
       jquery-rails
       railties (>= 3.1)
-    tzinfo (1.2.5)
+    tzinfo (1.2.6)
       thread_safe (~> 0.1)
     uber (0.1.0)
     uglifier (4.1.18)
@@ -961,4 +961,4 @@ DEPENDENCIES
   zipline (~> 1.0)
 
 BUNDLED WITH
-   2.0.2
+   2.1.4

--- a/app/actors/hyrax/actors/file_set_actor.rb
+++ b/app/actors/hyrax/actors/file_set_actor.rb
@@ -164,20 +164,25 @@ module Hyrax
         def unlink_from_work
           work = file_set.parent
           return unless work && (work.thumbnail_id == file_set.id || work.representative_id == file_set.id || work.rendering_ids.include?(file_set.id))
-          work.thumbnail = nil if work.thumbnail_id == file_set.id
-          work.representative = nil if work.representative_id == file_set.id
+
+          new_fileset = other_fileset(work) # is nil if no other fileset
+          work.thumbnail = new_fileset if work.thumbnail_id == file_set.id
+          work.representative = new_fileset if work.representative_id == file_set.id
           work.rendering_ids -= [file_set.id]
           work.save!
         end
-      # rubocop:enable Metrics/AbcSize
-      # rubocop:enable Metrics/CyclomaticComplexity
+        # rubocop:enable Metrics/AbcSize
+        # rubocop:enable Metrics/CyclomaticComplexity
+
+        def other_fileset(work)
+          work.file_sets.find { |fs| fs.id != file_set.id }
+        end
 
       def restrict_fileset(file_set)
         file_set.embargo_id = nil
         file_set.lease_id = nil
         file_set.visibility = 'restricted'
       end
-
     end
   end
 end


### PR DESCRIPTION
* Update iiif_manifest to use a commit where all manifests include only one FileSet, and no longer multiples for Image and Video works
* Deleting a FileSet for a work with multiple FileSets now re-assigns the thumbnail and representative to another FileSet as it should
* Due to updating Gemfile.lock, this also pushes the Bundler version to 2.1.4 (latest)