### PR TITLE
MR-705: Add Editor Status to Teams and Projects

### DIFF
--- a/app/helpers/morphosource/collection_roles_helper.rb
+++ b/app/helpers/morphosource/collection_roles_helper.rb
@@ -1,22 +1,28 @@
-module Morphosource::CollectionRolesHelper
+# frozen_string_literal: true
 
-  def ms_access_options
-     options_for_select(access_array)
+module Morphosource
+  # Provides select options for collection sharing
+  module CollectionRolesHelper
+    def ms_access_options
+      options_for_select(access_array)
+    end
+
+    def ms_edit_access_options(access)
+      options = access_array.reject { |option| option.include? access }
+      options_for_select(options << %w[Remove remove])
+    end
+
+    def collection_options
+      collections = @current_user.collections_managed
+      collections.delete(@collection)
+      options_for_select(collections.map { |c| [c.title.first, c.id] })
+    end
+
+    def access_array
+      roles = Collection::DEFAULT_GROUP_ROLES
+      roles.each_with_object([]) do |role, options|
+        options << [t('.' + role.dup.chop), role]
+      end
+    end
   end
-
-  def ms_edit_access_options(access)
-    options = access_array.select{|option| !option.include? access}
-    options_for_select(options << ['Remove', 'remove'])
-  end
-
-  def collection_options
-    collections = @current_user.collections_managed
-    collections.delete(@collection)
-    options_for_select(collections.map{|c| [c.title.first, c.id]})
-  end
-
-  def access_array
-    [[t('.manager'), 'managers'], [t('.depositor'), 'depositors'], [t('.viewer'), 'viewers']]
-  end
-
 end

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -11,20 +11,28 @@ class Collection < ActiveFedora::Base
 
   after_destroy :destroy_default_groups, if: :type_assigns_groups?
 
-  DEFAULT_GROUP_ROLES = %w[managers depositors viewers].freeze
+  # editors group grants members ability to edit works in the collection, but not to edit collection metadata or grant permissions
+  DEFAULT_GROUP_ROLES = %w[managers editors depositors viewers].freeze
+
+  # override Hyrax::CollectionBehavior to add editors to read_groups
+  def permission_template_read_groups
+    (permission_template.agent_ids_for(access: 'view', agent_type: 'group') + permission_template.agent_ids_for(access: 'edit_works', agent_type: 'group') +
+    permission_template.agent_ids_for(access: 'deposit', agent_type: 'group')).uniq -
+    [::Ability.registered_group_name, ::Ability.public_group_name]
+  end
 
   def type_assigns_groups?
     team? || project?
   end
 
-  # managers_group, depositors_group, and viewers_group methods
+  # managers_group, depositors_group, editors_group, and viewers_group methods
   DEFAULT_GROUP_ROLES.each do |role|
     define_method("#{role}_group") do
       Role.find_by(name: id.concat("_#{role}"))
     end
   end
 
-  # managers, depositors, viewers methods
+  # managers, depositors, editors, viewers methods
   DEFAULT_GROUP_ROLES.each do |role|
     define_method(role) do
       Role.find_by(name: id.concat("_#{role}")).users
@@ -40,7 +48,7 @@ class Collection < ActiveFedora::Base
   end
 
   def user_groups
-    [managers_group, depositors_group, viewers_group]
+    [managers_group, editors_group, depositors_group, viewers_group]
   end
 
   def user_groups_names
@@ -48,7 +56,7 @@ class Collection < ActiveFedora::Base
   end
 
   def group_members
-    managers + depositors + viewers
+    managers + editors + depositors + viewers
   end
 
   def first_parent

--- a/app/models/concerns/hyrax/ability/collection_ability.rb
+++ b/app/models/concerns/hyrax/ability/collection_ability.rb
@@ -1,0 +1,40 @@
+module Hyrax
+  module Ability
+    module CollectionAbility
+      def collection_abilities # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+        if admin?
+          can :manage, ::Collection
+          can :manage_any, ::Collection
+          can :create_any, ::Collection
+          can :view_admin_show_any, ::Collection
+        else
+          can :manage_any, ::Collection if Hyrax::Collections::PermissionsService.can_manage_any_collection?(ability: self)
+          can :create_any, ::Collection if Hyrax::CollectionTypes::PermissionsService.can_create_any_collection_type?(ability: self)
+          can :view_admin_show_any, ::Collection if Hyrax::Collections::PermissionsService.can_view_admin_show_for_any_collection?(ability: self)
+
+          can [:edit, :update, :destroy], ::Collection do |collection| # for test by solr_doc, see solr_document_ability.rb
+            test_edit(collection.id)
+          end
+
+          can :deposit, ::Collection do |collection|
+            Hyrax::Collections::PermissionsService.can_deposit_in_collection?(ability: self, collection_id: collection.id)
+          end
+          can :deposit, ::SolrDocument do |solr_doc|
+            Hyrax::Collections::PermissionsService.can_deposit_in_collection?(ability: self, collection_id: solr_doc.id) # checks collections and admin_sets
+          end
+
+          can :view_admin_show, ::Collection do |collection| # admin show page
+            Hyrax::Collections::PermissionsService.can_view_admin_show_for_collection?(ability: self, collection_id: collection.id)
+          end
+          can :view_admin_show, ::SolrDocument do |solr_doc| # admin show page
+            Hyrax::Collections::PermissionsService.can_view_admin_show_for_collection?(ability: self, collection_id: solr_doc.id) # checks collections and admin_sets
+          end
+
+          can :read, ::Collection do |collection| # public show page  # for test by solr_doc, see solr_document_ability.rb
+            test_read(collection.id)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/models/concerns/hyrax/ability/collection_ability.rb
+++ b/app/models/concerns/hyrax/ability/collection_ability.rb
@@ -16,6 +16,11 @@ module Hyrax
             test_edit(collection.id)
           end
 
+          # users can edit all works in a collection, but can't edit collection metadata or permissions
+          can :edit_works, ::Collection do |collection|
+            Hyrax::Collections::PermissionsService.can_edit_collection_works?(ability: self, collection_id: collection.id)
+          end
+
           can :deposit, ::Collection do |collection|
             Hyrax::Collections::PermissionsService.can_deposit_in_collection?(ability: self, collection_id: collection.id)
           end

--- a/app/models/hyrax/permission_template_access.rb
+++ b/app/models/hyrax/permission_template_access.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+module Hyrax
+  # Models a single grant of access to an agent (user or group) on a PermissionTemplate
+  class PermissionTemplateAccess < ActiveRecord::Base
+    self.table_name = 'permission_template_accesses'
+    belongs_to :permission_template
+
+    # An agent should only have any particular level of access once.
+    validates :access, uniqueness: {
+      scope: [:agent_id, :agent_type, :permission_template_id]
+    }
+
+    VIEW = 'view'
+    DEPOSIT = 'deposit'
+    EDIT_WORKS = 'edit_works'
+    MANAGE = 'manage'
+
+    GROUP = 'group'
+    USER = 'user'
+
+    enum(
+      access: {
+        VIEW => VIEW,
+        DEPOSIT => DEPOSIT,
+        EDIT_WORKS => EDIT_WORKS,
+        MANAGE => MANAGE
+      }
+    )
+
+    # @api public
+    #
+    # The permissions template access a given user has.
+    #
+    # @param access [Array<String>] one or more types of access (e.g. Hyrax::PermissionTemplateAccess::MANAGE, Hyrax::PermissionTemplateAccess::DEPOSIT, Hyrax::PermissionTemplateAccess::VIEW)
+    # @param ability [Ability] the ability coming from cancan ability check
+    # @param exclude_groups [Array<String>] name of groups to exclude from the results
+    # @return [ActiveRecord::Relation] relation of templates for which the user has specified roles
+    def self.for_user(ability:, access:, exclude_groups: [])
+      PermissionTemplateAccess.where(
+        user_where(access: access, ability: ability)
+      ).or(
+        PermissionTemplateAccess
+          .where(group_where(access: access, ability: ability, exclude_groups: exclude_groups))
+      )
+    end
+
+    def label
+      return agent_id unless agent_type == GROUP
+      case agent_id
+      when 'registered'
+        I18n.t('hyrax.admin.admin_sets.form_participant_table.registered_users')
+      when ::Ability.admin_group_name
+        I18n.t('hyrax.admin.admin_sets.form_participant_table.admin_users')
+      else
+        agent_id
+      end
+    end
+
+    def admin_group?
+      agent_type == GROUP && agent_id == ::Ability.admin_group_name
+    end
+
+    # @api private
+    #
+    # Generate the user where clause hash for joining the permissions tables
+    #
+    # @param access [Array<String>] one or more types of access (e.g. Hyrax::PermissionTemplateAccess::MANAGE, Hyrax::PermissionTemplateAccess::DEPOSIT, Hyrax::PermissionTemplateAccess::VIEW)
+    # @param ability [Ability] the cancan ability
+    # @return [Hash] the where clause hash to pass to joins for users
+    # @note Several checks get the user's groups from the user's ability.  The same values can be retrieved directly from a passed in ability.
+    #   If calling from Abilities, pass the ability.  If you try to get the ability from the user, you end up in an infinit loop.
+    def self.user_where(access:, ability:)
+      where_clause = {}
+      where_clause[:agent_type] = USER
+      where_clause[:agent_id] = ability.current_user.user_key
+      where_clause[:access] = access
+      where_clause
+    end
+    private_class_method :user_where
+
+    # @api private
+    #
+    # Generate the group where clause hash for joining the permissions tables
+    #
+    # @param access [Array<String>] one or more types of access (e.g. Hyrax::PermissionTemplateAccess::MANAGE, Hyrax::PermissionTemplateAccess::DEPOSIT, Hyrax::PermissionTemplateAccess::VIEW)
+    # @param ability [Ability] the cancan ability
+    # @param exclude_groups [Array<String>] name of groups to exclude from the results
+    # @return [Hash] the where clause hash to pass to joins for groups
+    # @note Several checks get the user's groups from the user's ability.  The same values can be retrieved directly from a passed in ability.
+    #   If calling from Abilities, pass the ability.  If you try to get the ability from the user, you end up in an infinit loop.
+    def self.group_where(access:, ability:, exclude_groups: [])
+      where_clause = {}
+      where_clause[:agent_type] = GROUP
+      where_clause[:agent_id] = ability.user_groups - exclude_groups
+      where_clause[:access] = access
+      where_clause
+    end
+    private_class_method :group_where
+  end
+end

--- a/app/services/hyrax/collections/permissions_service.rb
+++ b/app/services/hyrax/collections/permissions_service.rb
@@ -1,0 +1,255 @@
+module Hyrax
+  module Collections
+    class PermissionsService
+      # @api private
+      #
+      # IDs of collections/or admin_sets a user can access based on participant roles.
+      #
+      # @param access [Array<String>] one or more types of access (e.g. Hyrax::PermissionTemplateAccess::MANAGE, Hyrax::PermissionTemplateAccess::DEPOSIT, Hyrax::PermissionTemplateAccess::VIEW)
+      # @param ability [Ability] the ability coming from cancan ability check
+      # @param source_type [String] 'collection', 'admin_set', or nil to get all types
+      # @param exclude_groups [Array<String>] name of groups to exclude from the results
+      # @return [Array<String>] IDs of collections and admin sets for which the user has specified roles
+      def self.source_ids_for_user(access:, ability:, source_type: nil, exclude_groups: [])
+        scope = PermissionTemplateAccess.for_user(ability: ability, access: access, exclude_groups: exclude_groups)
+                                        .joins(:permission_template)
+        ids = scope.pluck('DISTINCT source_id')
+        return ids unless source_type
+        filter_source(source_type: source_type, ids: ids)
+      end
+      private_class_method :source_ids_for_user
+
+      def self.filter_source(source_type:, ids:)
+        return [] if ids.empty?
+        id_clause = "{!terms f=id}#{ids.join(',')}"
+        query = case source_type
+                when 'admin_set'
+                  "_query_:\"{!raw f=has_model_ssim}AdminSet\""
+                when 'collection'
+                  "_query_:\"{!raw f=has_model_ssim}Collection\""
+                end
+        query += " AND #{id_clause}"
+        ActiveFedora::SolrService.query(query, fl: 'id', rows: ids.count).map { |hit| hit['id'] }
+      end
+      private_class_method :filter_source
+
+      # @api private
+      #
+      # IDs of admin sets a user can access based on participant roles.
+      #
+      # @param access [Array<String>] one or more types of access (e.g. Hyrax::PermissionTemplateAccess::MANAGE, Hyrax::PermissionTemplateAccess::DEPOSIT, Hyrax::PermissionTemplateAccess::VIEW)
+      # @param ability [Ability] the ability coming from cancan ability check
+      # @return [Array<String>] IDs of admin sets for which the user has specified roles
+      # @note Several checks get the user's groups from the user's ability.  The same values can be retrieved directly from a passed in ability.
+      # TODO: MOVE TO ABILITY
+      def self.admin_set_ids_for_user(access:, ability:)
+        source_ids_for_user(access: access, ability: ability, source_type: 'admin_set')
+      end
+      private_class_method :admin_set_ids_for_user
+
+      # @api public
+      #
+      # IDs of collections a user can access based on participant roles.
+      #
+      # @param access [Array<String>] one or more types of access (e.g. Hyrax::PermissionTemplateAccess::MANAGE, Hyrax::PermissionTemplateAccess::DEPOSIT, Hyrax::PermissionTemplateAccess::VIEW)
+      # @param ability [Ability] the ability coming from cancan ability check
+      # @return [Array<String>] IDs of collections for which the user has specified roles
+      # @note Several checks get the user's groups from the user's ability.  The same values can be retrieved directly from a passed in ability.
+      def self.collection_ids_for_user(access:, ability:)
+        source_ids_for_user(access: access, ability: ability, source_type: 'collection')
+      end
+
+      # @api public
+      #
+      # IDs of collections and/or admin_sets into which a user can deposit.
+      #
+      # @param ability [Ability] the ability coming from cancan ability check
+      # @param source_type [String] 'collection', 'admin_set', or nil to get all types
+      # @param exclude_groups [Array<String>] name of groups to exclude from the results
+      # @return [Array<String>] IDs of collections and/or admin_sets into which the user can deposit
+      # @note Several checks get the user's groups from the user's ability.  The same values can be retrieved directly from a passed in ability.
+      def self.source_ids_for_deposit(ability:, source_type: nil, exclude_groups: [])
+        access = [Hyrax::PermissionTemplateAccess::MANAGE, Hyrax::PermissionTemplateAccess::DEPOSIT]
+        source_ids_for_user(access: access, ability: ability, source_type: source_type, exclude_groups: exclude_groups)
+      end
+
+      # @api public
+      #
+      # IDs of collections and/or admin_sets that a user can manage.
+      #
+      # @param ability [Ability] the ability coming from cancan ability check
+      # @param source_type [String] 'collection', 'admin_set', or nil to get all types
+      # @return [Array<String>] IDs of collections and/or admin_sets that the user can manage
+      # @note Several checks get the user's groups from the user's ability.  The same values can be retrieved directly from a passed in ability.
+      def self.source_ids_for_manage(ability:, source_type: nil)
+        access = [Hyrax::PermissionTemplateAccess::MANAGE, Hyrax::PermissionTemplateAccess::MANAGE]
+        source_ids_for_user(access: access, ability: ability, source_type: source_type)
+      end
+
+      # @api public
+      #
+      # IDs of collections into which a user can deposit.
+      #
+      # @param ability [Ability] the ability coming from cancan ability check
+      # @return [Array<String>] IDs of collections into which the user can deposit
+      # @note Several checks get the user's groups from the user's ability.  The same values can be retrieved directly from a passed in ability.
+      def self.collection_ids_for_deposit(ability:)
+        source_ids_for_deposit(ability: ability, source_type: 'collection')
+      end
+
+      # @api public
+      #
+      # IDs of collections which the user can view.
+      #
+      # @param ability [Ability] the ability coming from cancan ability check
+      # @return [Array<String>] IDs of collections into which the user can view
+      # @note Several checks get the user's groups from the user's ability.  The same values can be retrieved directly from a passed in ability.
+      def self.collection_ids_for_view(ability:)
+        collection_ids_for_user(ability: ability, access: [Hyrax::PermissionTemplateAccess::MANAGE,
+                                                           Hyrax::PermissionTemplateAccess::DEPOSIT,
+                                                           Hyrax::PermissionTemplateAccess::VIEW])
+      end
+
+      # @api public
+      #
+      # Determine if the given user has permissions to view the admin show page for at least one collection
+      #
+      # @param ability [Ability] the ability coming from cancan ability check
+      # @return [Boolean] true if the user has permission to view the admin show page for at least one collection
+      # @note Several checks get the user's groups from the user's ability.  The same values can be retrieved directly from a passed in ability.
+      def self.can_view_admin_show_for_any_collection?(ability:)
+        collection_ids_for_user(ability: ability, access: [Hyrax::PermissionTemplateAccess::MANAGE,
+                                                           Hyrax::PermissionTemplateAccess::DEPOSIT,
+                                                           Hyrax::PermissionTemplateAccess::VIEW]).present?
+      end
+
+      # @api public
+      #
+      # Determine if the given user has permissions to view the admin show page for at least one admin set
+      #
+      # @param ability [Ability] the ability coming from cancan ability check
+      # @return [Boolean] true if the user has permission to view the admin show page for at least one admin_set
+      # @note Several checks get the user's groups from the user's ability.  The same values can be retrieved directly from a passed in ability.
+      # TODO: MOVE TO ABILITY
+      def self.can_view_admin_show_for_any_admin_set?(ability:)
+        admin_set_ids_for_user(ability: ability, access: [Hyrax::PermissionTemplateAccess::MANAGE,
+                                                          Hyrax::PermissionTemplateAccess::DEPOSIT,
+                                                          Hyrax::PermissionTemplateAccess::VIEW]).present?
+      end
+
+      # @api public
+      #
+      # Determine if the given user has permissions to manage at least one collection
+      #
+      # @param ability [Ability] the ability coming from cancan ability check
+      # @return [Boolean] true if the user has permission to manage at least one collection
+      # @note Several checks get the user's groups from the user's ability.  The same values can be retrieved directly from a passed in ability.
+      def self.can_manage_any_collection?(ability:)
+        collection_ids_for_user(ability: ability, access: [Hyrax::PermissionTemplateAccess::MANAGE]).present?
+      end
+
+      # @api public
+      #
+      # Determine if the given user has permissions to manage at least one admin set
+      #
+      # @param ability [Ability] the ability coming from cancan ability check
+      # @return [Boolean] true if the user has permission to manage at least one admin_set
+      # @note Several checks get the user's groups from the user's ability.  The same values can be retrieved directly from a passed in ability.
+      # TODO: MOVE TO ABILITY
+
+      def self.can_manage_any_admin_set?(ability:)
+        admin_set_ids_for_user(ability: ability, access: [Hyrax::PermissionTemplateAccess::MANAGE]).present?
+      end
+
+      # @api public
+      #
+      # Determine if the given user has permissions to deposit into the given collection
+      #
+      # @param collection_id [String] id of the collection we are checking permissions on
+      # @param ability [Ability] the ability coming from cancan ability check
+      # @return [Boolean] true if the user has permission to deposit into the collection
+      # @note Several checks get the user's groups from the user's ability.  The same values can be retrieved directly from a passed in ability.
+      def self.can_deposit_in_collection?(collection_id:, ability:)
+        deposit_access_to_collection?(collection_id: collection_id, ability: ability) ||
+          manage_access_to_collection?(collection_id: collection_id, ability: ability)
+      end
+
+      # @api public
+      #
+      # Determine if the given user has permissions to view the admin show page for the collection
+      #
+      # @param collection_id [String] id of the collection we are checking permissions on
+      # @param ability [Ability] the ability coming from cancan ability check
+      # @return [Boolean] true if the user has permission to view the admin show page for the collection
+      # @note Several checks get the user's groups from the user's ability.  The same values can be retrieved directly from a passed in ability.
+      def self.can_view_admin_show_for_collection?(collection_id:, ability:)
+        exclude_groups = [::Ability.registered_group_name,
+                          ::Ability.public_group_name]
+        manage_access_to_collection?(collection_id: collection_id, ability: ability) ||
+          deposit_access_to_collection?(collection_id: collection_id, ability: ability, exclude_groups: exclude_groups) ||
+          view_access_to_collection?(collection_id: collection_id, ability: ability, exclude_groups: exclude_groups)
+      end
+
+      # @api private
+      #
+      # Determine if the given user has :deposit access for the given collection
+      #
+      # @param collection_id [String] id of the collection we are checking permissions on
+      # @param ability [Ability] the ability coming from cancan ability check
+      # @param exclude_groups [Array<String>] name of groups to exclude from the results
+      # @return [Boolean] true if the user has :deposit access to the collection
+      # @note Several checks get the user's groups from the user's ability.  The same values can be retrieved directly from a passed in ability.
+      def self.deposit_access_to_collection?(collection_id:, ability: nil, exclude_groups: [])
+        access_to_collection?(collection_id: collection_id, access: 'deposit', ability: ability, exclude_groups: exclude_groups)
+      end
+      private_class_method :deposit_access_to_collection?
+
+      # @api private
+      #
+      # Determine if the given user has :manage access for the given collection
+      #
+      # @param collection_id [String] id of the collection we are checking permissions on
+      # @param ability [Ability] the ability coming from cancan ability check
+      # @param exclude_groups [Array<String>] name of groups to exclude from the results
+      # @return [Boolean] true if the user has :manage access to the collection
+      # @note Several checks get the user's groups from the user's ability.  The same values can be retrieved directly from a passed in ability.
+      def self.manage_access_to_collection?(collection_id:, ability:, exclude_groups: [])
+        access_to_collection?(collection_id: collection_id, access: 'manage', ability: ability, exclude_groups: exclude_groups)
+      end
+      private_class_method :manage_access_to_collection?
+
+      # @api private
+      #
+      # Determine if the given user has :view access for the given collection
+      #
+      # @param collection_id [String] id of the collection we are checking permissions on
+      # @param ability [Ability] the ability coming from cancan ability check
+      # @param exclude_groups [Array<String>] name of groups to exclude from the results
+      # @return [Boolean] true if the user has permission to view the collection
+      # @note Several checks get the user's groups from the user's ability.  The same values can be retrieved directly from a passed in ability.
+      def self.view_access_to_collection?(collection_id:, ability:, exclude_groups: [])
+        access_to_collection?(collection_id: collection_id, access: 'view', ability: ability, exclude_groups: exclude_groups)
+      end
+      private_class_method :view_access_to_collection?
+
+      # @api private
+      #
+      # Determine if the given user has specified access for the given collection
+      #
+      # @param collection_id [String] id of the collection we are checking permissions on
+      # @param access [Symbol] the access level to check
+      # @param ability [Ability] the ability coming from cancan ability check
+      # @param exclude_groups [Array<String>] name of groups to exclude from the results
+      # @return [Boolean] true if the user has permission to view the collection
+      # @note Several checks get the user's groups from the user's ability.  The same values can be retrieved directly from a passed in ability.
+      def self.access_to_collection?(collection_id:, access:, ability:, exclude_groups: [])
+        return false unless collection_id
+        template = Hyrax::PermissionTemplate.find_by!(source_id: collection_id)
+        return true if ([ability.current_user.user_key] & template.agent_ids_for(agent_type: 'user', access: access)).present?
+        return true if (ability.user_groups & (template.agent_ids_for(agent_type: 'group', access: access) - exclude_groups)).present?
+        false
+      end
+      private_class_method :access_to_collection?
+    end
+  end
+end

--- a/app/services/hyrax/collections/permissions_service.rb
+++ b/app/services/hyrax/collections/permissions_service.rb
@@ -69,7 +69,7 @@ module Hyrax
       # @return [Array<String>] IDs of collections and/or admin_sets into which the user can deposit
       # @note Several checks get the user's groups from the user's ability.  The same values can be retrieved directly from a passed in ability.
       def self.source_ids_for_deposit(ability:, source_type: nil, exclude_groups: [])
-        access = [Hyrax::PermissionTemplateAccess::MANAGE, Hyrax::PermissionTemplateAccess::DEPOSIT]
+        access = [Hyrax::PermissionTemplateAccess::MANAGE, Hyrax::PermissionTemplateAccess::EDIT_WORKS, Hyrax::PermissionTemplateAccess::DEPOSIT]
         source_ids_for_user(access: access, ability: ability, source_type: source_type, exclude_groups: exclude_groups)
       end
 
@@ -84,6 +84,10 @@ module Hyrax
       def self.source_ids_for_manage(ability:, source_type: nil)
         access = [Hyrax::PermissionTemplateAccess::MANAGE, Hyrax::PermissionTemplateAccess::MANAGE]
         source_ids_for_user(access: access, ability: ability, source_type: source_type)
+      end
+
+      def self.collection_ids_for_edit_works(ability:)
+        collection_ids_for_user(ability: ability, access: [Hyrax::PermissionTemplateAccess::MANAGE, Hyrax::PermissionTemplateAccess::EDIT_WORKS])
       end
 
       # @api public
@@ -105,7 +109,7 @@ module Hyrax
       # @return [Array<String>] IDs of collections into which the user can view
       # @note Several checks get the user's groups from the user's ability.  The same values can be retrieved directly from a passed in ability.
       def self.collection_ids_for_view(ability:)
-        collection_ids_for_user(ability: ability, access: [Hyrax::PermissionTemplateAccess::MANAGE,
+        collection_ids_for_user(ability: ability, access: [Hyrax::PermissionTemplateAccess::MANAGE, Hyrax::PermissionTemplateAccess::EDIT_WORKS,
                                                            Hyrax::PermissionTemplateAccess::DEPOSIT,
                                                            Hyrax::PermissionTemplateAccess::VIEW])
       end
@@ -118,7 +122,7 @@ module Hyrax
       # @return [Boolean] true if the user has permission to view the admin show page for at least one collection
       # @note Several checks get the user's groups from the user's ability.  The same values can be retrieved directly from a passed in ability.
       def self.can_view_admin_show_for_any_collection?(ability:)
-        collection_ids_for_user(ability: ability, access: [Hyrax::PermissionTemplateAccess::MANAGE,
+        collection_ids_for_user(ability: ability, access: [Hyrax::PermissionTemplateAccess::MANAGE, Hyrax::PermissionTemplateAccess::EDIT_WORKS,
                                                            Hyrax::PermissionTemplateAccess::DEPOSIT,
                                                            Hyrax::PermissionTemplateAccess::VIEW]).present?
       end
@@ -170,7 +174,7 @@ module Hyrax
       # @return [Boolean] true if the user has permission to deposit into the collection
       # @note Several checks get the user's groups from the user's ability.  The same values can be retrieved directly from a passed in ability.
       def self.can_deposit_in_collection?(collection_id:, ability:)
-        deposit_access_to_collection?(collection_id: collection_id, ability: ability) ||
+        deposit_access_to_collection?(collection_id: collection_id, ability: ability) || edit_works_access_to_collection?(collection_id: collection_id, ability: ability) ||
           manage_access_to_collection?(collection_id: collection_id, ability: ability)
       end
 
@@ -186,6 +190,7 @@ module Hyrax
         exclude_groups = [::Ability.registered_group_name,
                           ::Ability.public_group_name]
         manage_access_to_collection?(collection_id: collection_id, ability: ability) ||
+          edit_works_access_to_collection?(collection_id: collection_id, ability: ability, exclude_groups: exclude_groups) ||
           deposit_access_to_collection?(collection_id: collection_id, ability: ability, exclude_groups: exclude_groups) ||
           view_access_to_collection?(collection_id: collection_id, ability: ability, exclude_groups: exclude_groups)
       end
@@ -231,6 +236,28 @@ module Hyrax
         access_to_collection?(collection_id: collection_id, access: 'view', ability: ability, exclude_groups: exclude_groups)
       end
       private_class_method :view_access_to_collection?
+
+      # @api public
+      #
+      # Determine if the given user has permissions to edit all works created through the given collection
+      def self.can_edit_collection_works?(collection_id:, ability:)
+        edit_works_access_to_collection?(collection_id: collection_id, ability: ability) ||
+          manage_access_to_collection?(collection_id: collection_id, ability: ability)
+      end
+
+      # @api private
+      #
+      # Determine if the given user has :deposit access for the given collection
+      #
+      # @param collection_id [String] id of the collection we are checking permissions on
+      # @param ability [Ability] the ability coming from cancan ability check
+      # @param exclude_groups [Array<String>] name of groups to exclude from the results
+      # @return [Boolean] true if the user has :deposit access to the collection
+      # @note Several checks get the user's groups from the user's ability.  The same values can be retrieved directly from a passed in ability.
+      def self.edit_works_access_to_collection?(collection_id:, ability: nil, exclude_groups: [])
+        access_to_collection?(collection_id: collection_id, access: 'edit_works', ability: ability, exclude_groups: exclude_groups)
+      end
+      private_class_method :edit_works_access_to_collection?
 
       # @api private
       #

--- a/app/services/hyrax/permission_template_applicator.rb
+++ b/app/services/hyrax/permission_template_applicator.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+module Hyrax
+  ##
+  # Applies a `PermissionTemplate` to a given model object by adding the
+  # template's manage and view users to the model's permissions.
+  #
+  # @example applying a template
+  #   applicator = PermissionTemplateApplicator.new(template: my_template)
+  #   applicator.apply_to(work)
+  #
+  # @example applying a template with fluent chaining syntax
+  #   PermissionTemplateApplicator.apply(my_template).to work
+  #
+  # @since 2.4.0
+  class PermissionTemplateApplicator
+    ##
+    # @!attribute [rw] template
+    #   @return [Hyrax::PermissionTemplate]
+    attr_accessor :template
+
+    ##
+    # @param template [Hyrax::PermissionTemplate]
+    def initialize(template:)
+      self.template = template
+    end
+
+    ##
+    # @param template [Hyrax::PermissionTemplate]
+    #
+    # @return [PermissionTemplateApplicator]
+    def self.apply(template)
+      new(template: template)
+    end
+
+    ##
+    # @param model [Hydra::PCDM::Object, Hydra::PCDM::Collection]
+    # @return [Boolean] true if the permissions have been successfully applied
+    def apply_to(model:)
+      model.edit_groups += template.agent_ids_for(agent_type: 'group', access: 'manage')
+      model.edit_users  += template.agent_ids_for(agent_type: 'user',  access: 'manage')
+      model.read_groups += template.agent_ids_for(agent_type: 'group', access: 'view')
+      model.read_users  += template.agent_ids_for(agent_type: 'user',  access: 'view')
+
+      true
+    end
+    alias to apply_to
+  end
+end

--- a/app/services/hyrax/permission_template_applicator.rb
+++ b/app/services/hyrax/permission_template_applicator.rb
@@ -37,6 +37,8 @@ module Hyrax
     # @return [Boolean] true if the permissions have been successfully applied
     def apply_to(model:)
       model.edit_groups += template.agent_ids_for(agent_type: 'group', access: 'manage')
+      # add edit access for collection editors group
+      model.edit_groups += template.agent_ids_for(agent_type: 'group', access: 'edit_works')
       model.edit_users  += template.agent_ids_for(agent_type: 'user',  access: 'manage')
       model.read_groups += template.agent_ids_for(agent_type: 'group', access: 'view')
       model.read_users  += template.agent_ids_for(agent_type: 'user',  access: 'view')

--- a/app/views/hyrax/dashboard/collections/_ms_form_share.html.erb
+++ b/app/views/hyrax/dashboard/collections/_ms_form_share.html.erb
@@ -50,6 +50,7 @@
     <section class="section-collection-sharing">
       <legend><%= t(".current_shared") %></legend>
       <%= render 'ms_form_share_table', access: 'managers', filter: :manage? %>
+      <%= render 'ms_form_share_table', access: 'editors', filter: :edit_works? %>
       <%= render 'ms_form_share_table', access: 'depositors', filter: :deposit? %>
       <%= render 'ms_form_share_table', access: 'viewers', filter: :view? %>
     </section>

--- a/app/views/hyrax/dashboard/collections/_ms_form_share_table.html.erb
+++ b/app/views/hyrax/dashboard/collections/_ms_form_share_table.html.erb
@@ -1,8 +1,15 @@
 <% group_name = access.dup.concat("_group") %>
 <% group = @collection.send(group_name) %>
-<h3><%= t("hyrax.dashboard.collections.form_share_table.#{access}.title") %></h3>
-<p><%= t("hyrax.dashboard.collections.form_share_table.#{access}.help") %></p>
-<p><%= t("hyrax.dashboard.collections.form_share_table.#{access}.help_with_works", type_title: @collection.collection_type.title) if @collection.share_applies_to_new_works? && access != 'depositors' %></p>
+<% if access == 'editors' %>
+  <h3>Editors</h3>
+  <p>Editors of this collection can view the collection and add works to it, even if the visibility permissions of the collection otherwise would not permit them to view it. Editors cannot modify collection metadata, delete the collection, or share the collection with others.</p>
+  <p>When works are created directly in this collection, editors are given edit access to the work.</p>
+<% else %>
+  <h3><%= t("hyrax.dashboard.collections.form_share_table.#{access}.title") %></h3>
+  <p><%= t("hyrax.dashboard.collections.form_share_table.#{access}.help") %></p>
+  <p><%= t("hyrax.dashboard.collections.form_share_table.#{access}.help_with_works", type_title: @collection.collection_type.title) if @collection.share_applies_to_new_works? && access != 'depositors' %></p>
+<% end %>
+
 <% if group.users.count > 0 %>
   <table class="table table-striped share-status">
     <thead>

--- a/config/initializers/morphosource/collections_controller.rb
+++ b/config/initializers/morphosource/collections_controller.rb
@@ -4,9 +4,6 @@ Hyrax::Dashboard::CollectionsController.class_eval do
   helper Morphosource::CollectionRolesHelper
 
   def after_create
-    # TODO: Experiencing occasional bug where this code is not called when expected. Puts statements below to assist in debugging
-    puts 'Custom CollectionsController after_create called'
-    puts "@collection.type_assigns_groups?:   #{@collection.type_assigns_groups?}"
     form
     choose_permissions
     # if we are creating the new collection as a subcollection (via the nested collections controller),
@@ -28,8 +25,6 @@ Hyrax::Dashboard::CollectionsController.class_eval do
   end
 
   def set_morphosource_permissions
-    # TODO: Experiencing occasional bug where this code is not called when expected. Puts statements below to assist in debugging
-    puts 'set_morphosource_permissions called'
     @collection.create_collection_groups
     @collection.copy_parent_membership(params[:parent_id]) unless params[:parent_id].nil?
     Hyrax::Collections::PermissionsCreateService.create_ms_template(collection: @collection)

--- a/config/initializers/morphosource/permissions_create_service.rb
+++ b/config/initializers/morphosource/permissions_create_service.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Hyrax::Collections::PermissionsCreateService.module_eval do
-  # Assign new groups to manager/depositor/viewer access if collection is a Team or Project
+  # Assign new groups to manager/editor/depositor/viewer access if collection is a Team or Project
   def self.create_ms_template(collection:)
     access_grants = ms_access_grants_attributes(collection: collection)
     Hyrax::PermissionTemplate.create!(source_id: collection.id, access_grants_attributes: access_grants.uniq)
@@ -11,10 +11,10 @@ Hyrax::Collections::PermissionsCreateService.module_eval do
   # Add auto-generated groups.
   # Don't give creating_user individual manager status since they are already added to the manager group.
   def self.ms_access_grants_attributes(collection:)
-    puts '     ms_access_grants_attributes called     '
     [
       { agent_type: 'group', agent_id: admin_group_name, access: Hyrax::PermissionTemplateAccess::MANAGE },
       { agent_type: 'group', agent_id: collection.managers_group.name, access: Hyrax::PermissionTemplateAccess::MANAGE },
+      { agent_type: 'group', agent_id: collection.editors_group.name, access: Hyrax::PermissionTemplateAccess::EDIT_WORKS },
       { agent_type: 'group', agent_id: collection.depositors_group.name, access: Hyrax::PermissionTemplateAccess::DEPOSIT },
       { agent_type: 'group', agent_id: collection.viewers_group.name, access: Hyrax::PermissionTemplateAccess::VIEW }
     ] + managers_of_collection_type(collection_type: collection.collection_type)

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -105,6 +105,7 @@ en:
       collections:
         form_share:
           manager: 'Manager'
+          editor: 'Editor'
           depositor: 'Depositor'
           viewer: 'Viewer'
     works:

--- a/spec/config/permissions_create_service_spec.rb
+++ b/spec/config/permissions_create_service_spec.rb
@@ -42,9 +42,10 @@ RSpec.describe Hyrax::Collections::PermissionsCreateService do
       let(:collection) { team_a }
 
       it 'assigns admins and collection groups to appropriate access levels' do
-        expect(access_grants.count).to be(4)
+        expect(access_grants.count).to be(5)
         expect(admin[:access]).to eq(Hyrax::PermissionTemplateAccess::MANAGE)
         expect(managers[:access]).to eq(Hyrax::PermissionTemplateAccess::MANAGE)
+        expect(editors[:access]).to eq(Hyrax::PermissionTemplateAccess::EDIT_WORKS)
         expect(depositors[:access]).to eq(Hyrax::PermissionTemplateAccess::DEPOSIT)
         expect(viewers[:access]).to eq(Hyrax::PermissionTemplateAccess::VIEW)
       end
@@ -53,9 +54,10 @@ RSpec.describe Hyrax::Collections::PermissionsCreateService do
       let(:collection) { project_a }
 
       it 'assigns admins and collection groups to appropriate access levels' do
-        expect(access_grants.count).to be(4)
+        expect(access_grants.count).to be(5)
         expect(admin[:access]).to eq(Hyrax::PermissionTemplateAccess::MANAGE)
         expect(managers[:access]).to eq(Hyrax::PermissionTemplateAccess::MANAGE)
+        expect(editors[:access]).to eq(Hyrax::PermissionTemplateAccess::EDIT_WORKS)
         expect(depositors[:access]).to eq(Hyrax::PermissionTemplateAccess::DEPOSIT)
         expect(viewers[:access]).to eq(Hyrax::PermissionTemplateAccess::VIEW)
       end

--- a/spec/helpers/morphosource/collection_roles_helper_spec.rb
+++ b/spec/helpers/morphosource/collection_roles_helper_spec.rb
@@ -1,27 +1,30 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Morphosource::CollectionRolesHelper, type: :helper do
-
   before do
     helper.instance_variable_set(:@virtual_path, 'hyrax.dashboard.collections.form_share')
   end
 
   describe '#ms_access_options' do
-
-    it 'returns options for manager, depositor, and viewer' do
-      expect(helper.ms_access_options).to eq("<option value=\"managers\">Manager</option>\n<option value=\"depositors\">Depositor</option>\n<option value=\"viewers\">Viewer</option>")
+    it 'returns options for manager, editor, depositor, and viewer' do
+      expect(helper.ms_access_options).to eq("<option value=\"managers\">Manager</option>\n<option value=\"editors\">Editor</option>\n<option value=\"depositors\">Depositor</option>\n<option value=\"viewers\">Viewer</option>")
     end
   end
 
   describe 'ms_edit_access_options' do
     context 'current managers' do
-      it { expect(helper.ms_edit_access_options('managers')).to eq("<option value=\"depositors\">Depositor</option>\n<option value=\"viewers\">Viewer</option>\n<option value=\"remove\">Remove</option>") }
+      it { expect(helper.ms_edit_access_options('managers')).to eq("<option value=\"editors\">Editor</option>\n<option value=\"depositors\">Depositor</option>\n<option value=\"viewers\">Viewer</option>\n<option value=\"remove\">Remove</option>") }
+    end
+    context 'current editors' do
+      it { expect(helper.ms_edit_access_options('editors')).to eq("<option value=\"managers\">Manager</option>\n<option value=\"depositors\">Depositor</option>\n<option value=\"viewers\">Viewer</option>\n<option value=\"remove\">Remove</option>") }
     end
     context 'current depositors' do
-      it { expect(helper.ms_edit_access_options('depositors')).to eq("<option value=\"managers\">Manager</option>\n<option value=\"viewers\">Viewer</option>\n<option value=\"remove\">Remove</option>") }
+      it { expect(helper.ms_edit_access_options('depositors')).to eq("<option value=\"managers\">Manager</option>\n<option value=\"editors\">Editor</option>\n<option value=\"viewers\">Viewer</option>\n<option value=\"remove\">Remove</option>") }
     end
     context 'current viewers' do
-      it { expect(helper.ms_edit_access_options('viewers')).to eq("<option value=\"managers\">Manager</option>\n<option value=\"depositors\">Depositor</option>\n<option value=\"remove\">Remove</option>") }
+      it { expect(helper.ms_edit_access_options('viewers')).to eq("<option value=\"managers\">Manager</option>\n<option value=\"editors\">Editor</option>\n<option value=\"depositors\">Depositor</option>\n<option value=\"remove\">Remove</option>") }
     end
   end
 

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -12,10 +12,6 @@ RSpec.describe Collection, type: :model do
 
   let(:project) { Collection.create(title: ['Project_B'], collection_type_gid: project_collection_type.gid, depositor: user.ms_id) }
 
-  before do
-    allow(User).to receive(:find_by).with(ms_id: user.ms_id).and_return(user)
-  end
-
   describe '#organization' do
     let!(:org1)  { Organization.create(title: ['title'], team_id: [team.id]) }
     let!(:org2)  { Organization.create(title: ['title'], team_id: []) }
@@ -26,10 +22,23 @@ RSpec.describe Collection, type: :model do
     end
   end
 
+  # override Hyrax::CollectionBehavior to add editors to read_groups
+  describe '#permission_template_read_groups' do
+    before do
+      team.create_collection_groups
+      Hyrax::Collections::PermissionsCreateService.create_ms_template(collection: team)
+    end
+
+    it 'returns collection editors, depositors, and viewers' do
+      expect(team.permission_template_read_groups).to match_array([team.editors_group, team.depositors_group, team.viewers_group].map(&:name))
+    end
+
+  end
+
   describe '#create_collection_groups' do
 
-    it 'creates manager, depositor, and viewer groups' do
-      expect { team.create_collection_groups }.to change { Role.count }.by(3)
+    it 'creates manager, depositor, editor, and viewer groups' do
+      expect { team.create_collection_groups }.to change { Role.count }.by(4)
     end
 
     it 'assigns them names with the collection id' do
@@ -49,6 +58,7 @@ RSpec.describe Collection, type: :model do
   describe '#copy_parent_membership' do
     let(:parent) { Collection.create(title: ['Parent'], collection_type_gid: team_collection_type.gid, depositor: user.ms_id) }
     let(:parent_manager) { User.create(email: 'manager@email.com', password: 'password') }
+    let(:parent_editor) { User.create(email: 'editor@email.com', password: 'password') }
     let(:parent_depositor) { User.create(email: 'depositor@email.com', password: 'password') }
     let(:parent_viewer) { User.create(email: 'viewer@email.com', password: 'password') }
 
@@ -65,6 +75,7 @@ RSpec.describe Collection, type: :model do
       end
 
       parent.managers << parent_manager
+      parent.editors << parent_editor
       parent.depositors << parent_depositor
       parent.viewers << parent_viewer
       parent.user_groups.each(&:save)
@@ -74,6 +85,7 @@ RSpec.describe Collection, type: :model do
 
     it 'copies the parent members to the child collection' do
       expect(project.managers).to include(parent_manager)
+      expect(project.editors).to include(parent_editor)
       expect(project.depositors).to include(parent_depositor)
       expect(project.viewers).to include(parent_viewer)
     end
@@ -92,15 +104,17 @@ RSpec.describe Collection, type: :model do
     before do
       collection.create_collection_groups
       collection.managers_group.users << user1 << user2
-      collection.depositors_group.users << user3 << user4
+      collection.editors_group.users << user3
+      collection.depositors_group.users << user4
       collection.viewers_group.users << user5 << user6
       collection.user_groups.each(&:save)
     end
 
-    describe '#managers, #depositors, #viewers' do
+    describe '#managers, #editors, #depositors, #viewers' do
       it 'returns users for each of the different roles' do
         expect(collection.managers).to match_array([user, user1, user2])
-        expect(collection.depositors).to match_array([user3, user4])
+        expect(collection.editors).to match_array([user3])
+        expect(collection.depositors).to match_array([user4])
         expect(collection.viewers).to match_array([user5, user6])
       end
     end
@@ -132,7 +146,7 @@ RSpec.describe Collection, type: :model do
 
       it 'destroys all of the default user groups when a team or project is destroyed' do
         team.create_collection_groups
-        expect { team.destroy }.to change { Role.count }.by(-3)
+        expect { team.destroy }.to change { Role.count }.by(-4)
       end
     end
   end

--- a/spec/models/concerns/hyrax/ability/collection_ability_spec.rb
+++ b/spec/models/concerns/hyrax/ability/collection_ability_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'cancan/matchers'
+require 'rails_helper'
+
+RSpec.describe 'Hyrax::Ability::CollectionAbility' do
+  subject { ability }
+
+  let!(:user)           { User.create(email: 'email@email.com', password: 'password') }
+  let(:current_user)    { user }
+  let(:ability)         { Ability.new(current_user) }
+  let!(:depositor)      { User.create(email: 'email2@email.com', password: 'password') }
+  let(:collection_type) { Hyrax::CollectionType.create(title: 'Team', machine_id: 'team') }
+
+  context 'when collection editor' do
+    let!(:collection)    { Collection.create(id: 'Team', title: ['Team'], depositor: depositor.ms_id, collection_type_gid: collection_type.gid) }
+    let!(:solr_document) { SolrDocument.new(collection.to_solr) }
+
+    before do
+      collection.create_collection_groups
+      collection.editors << current_user
+      collection.editors_group.save
+
+      Hyrax::Collections::PermissionsCreateService.create_ms_template(collection: collection)
+
+      collection.reset_access_controls!
+    end
+
+    it 'allows editor related abilities' do
+      is_expected.to be_able_to(:view_admin_show_any, Collection)
+      is_expected.to be_able_to(:deposit, collection)
+      is_expected.to be_able_to(:deposit, solr_document)
+      is_expected.to be_able_to(:view_admin_show, collection)
+      is_expected.to be_able_to(:view_admin_show, solr_document)
+      is_expected.to be_able_to(:read, collection)
+      is_expected.to be_able_to(:read, solr_document) # defined in solr_document_ability.rb
+    end
+
+    it 'denies non-editor related abilities' do 
+      is_expected.not_to be_able_to(:manage, Collection)
+      is_expected.not_to be_able_to(:manage_any, Collection)
+      is_expected.not_to be_able_to(:edit, collection)
+      is_expected.not_to be_able_to(:edit, solr_document) # defined in solr_document_ability.rb
+      is_expected.not_to be_able_to(:update, collection)
+      is_expected.not_to be_able_to(:update, solr_document) # defined in solr_document_ability.rb
+      is_expected.not_to be_able_to(:destroy, collection)
+      is_expected.not_to be_able_to(:destroy, solr_document) # defined in solr_document_ability.rb
+    end
+  end
+end

--- a/spec/models/hyrax/permission_template_access_spec.rb
+++ b/spec/models/hyrax/permission_template_access_spec.rb
@@ -1,0 +1,221 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Hyrax::PermissionTemplateAccess do
+  let(:depositor)            { User.create(email: 'depositor@email.com', password: 'password') }
+  let(:team_collection_type) { Hyrax::CollectionType.create(title: 'Team', machine_id: 88) }
+  let(:collection)           { Collection.create(id: 'team', title: ['Team'], depositor: depositor.ms_id, collection_type_gid: team_collection_type.gid) }
+
+  before do
+    collection.create_collection_groups
+    Hyrax::Collections::PermissionsCreateService.create_ms_template(collection: collection)
+
+    collection.reset_access_controls!
+  end
+
+  describe 'default team/project template grants #label, #admin_group, #destroy' do
+    let(:access_grants) { collection.permission_template.access_grants }
+
+    context 'with the admin users group' do
+      subject { access_grants.detect{ |grant| grant[:agent_id] == 'admin' } }
+
+      describe '#label' do
+        it 'returns the repo admins label' do
+          expect(subject.label).to eq 'Repository Administrators'
+        end
+      end
+      describe '#admin_group?' do
+        it 'returns true' do
+          expect(subject).to be_admin_group
+        end
+      end
+      describe '#destroy' do
+        it 'destroys the permission template access record' do
+          subject.destroy
+          expect(subject).to be_destroyed
+        end
+      end
+    end
+
+    context 'with the managers group' do
+      subject { access_grants.detect{ |grant| grant[:access] == "manage" && grant[:agent_id] == 'team_managers' } }
+
+      describe '#label' do
+        it 'returns the collection editors label' do
+          expect(subject.label).to eq 'team_managers'
+        end
+      end
+      describe '#admin_group?' do
+        it 'returns false' do
+          expect(subject).not_to be_admin_group
+        end
+      end
+      describe '#destroy' do
+        it 'destroys the permission template access record' do
+          subject.destroy
+          expect(subject).to be_destroyed
+        end
+      end
+    end
+
+    context 'with the editors group' do
+      subject { access_grants.detect{ |grant| grant[:access] == "edit_works" } }
+
+      describe '#label' do
+        it 'returns the collection editors label' do
+          expect(subject.label).to eq 'team_editors'
+        end
+      end
+      describe '#admin_group?' do
+        it 'returns false' do
+          expect(subject).not_to be_admin_group
+        end
+      end
+      describe '#destroy' do
+        it 'destroys the permission template access record' do
+          subject.destroy
+          expect(subject).to be_destroyed
+        end
+      end
+    end
+
+    context 'with the depositors group' do
+      subject { access_grants.detect{ |grant| grant[:access] == "deposit" } }
+
+      describe '#label' do
+        it 'returns the collection editors label' do
+          expect(subject.label).to eq 'team_depositors'
+        end
+      end
+      describe '#admin_group?' do
+        it 'returns false' do
+          expect(subject).not_to be_admin_group
+        end
+      end
+      describe '#destroy' do
+        it 'destroys the permission template access record' do
+          subject.destroy
+          expect(subject).to be_destroyed
+        end
+      end
+    end
+
+    context 'with the editors group' do
+      subject { access_grants.detect{ |grant| grant[:access] == "view" } }
+
+      describe '#label' do
+        it 'returns the collection editors label' do
+          expect(subject.label).to eq 'team_viewers'
+        end
+      end
+      describe '#admin_group?' do
+        it 'returns false' do
+          expect(subject).not_to be_admin_group
+        end
+      end
+      describe '#destroy' do
+        it 'destroys the permission template access record' do
+          subject.destroy
+          expect(subject).to be_destroyed
+        end
+      end
+    end
+
+    context 'with a user that is a collection viewer' do
+      let(:permission_template_access) { Hyrax::PermissionTemplateAccess.create!(permission_template: collection.permission_template, agent_type: 'user', agent_id: 'agent_id', access: Hyrax::PermissionTemplateAccess::VIEW) }
+
+      subject { permission_template_access }
+
+      describe '#label' do
+        it 'returns the user label' do
+          expect(subject.label).to eq 'agent_id'
+        end
+      end
+      describe '#admin_group?' do
+        it 'returns true' do
+          expect(subject).not_to be_admin_group
+        end
+      end
+      describe '#destroy' do
+        it 'carries out the destroy operation' do
+          subject.destroy
+          expect(subject).to be_destroyed
+          expect(subject.errors).to be_empty
+        end
+      end
+    end
+
+    context 'with a user that is a collection depositor' do
+      let(:permission_template_access) { Hyrax::PermissionTemplateAccess.create!(permission_template: collection.permission_template, agent_type: 'user', agent_id: 'agent_id', access: Hyrax::PermissionTemplateAccess::DEPOSIT) }
+
+      subject { permission_template_access }
+
+      describe '#label' do
+        it 'returns the user label' do
+          expect(subject.label).to eq 'agent_id'
+        end
+      end
+      describe '#admin_group?' do
+        it 'returns true' do
+          expect(subject).not_to be_admin_group
+        end
+      end
+      describe '#destroy' do
+        it 'carries out the destroy operation' do
+          subject.destroy
+          expect(subject).to be_destroyed
+          expect(subject.errors).to be_empty
+        end
+      end
+    end
+
+    context 'with a user that is a collection editor' do
+      let(:permission_template_access) { Hyrax::PermissionTemplateAccess.create!(permission_template: collection.permission_template, agent_type: 'user', agent_id: 'agent_id', access: Hyrax::PermissionTemplateAccess::EDIT_WORKS) }
+
+      subject { permission_template_access }
+
+      describe '#label' do
+        it 'returns the user label' do
+          expect(subject.label).to eq 'agent_id'
+        end
+      end
+      describe '#admin_group?' do
+        it 'returns true' do
+          expect(subject).not_to be_admin_group
+        end
+      end
+      describe '#destroy' do
+        it 'carries out the destroy operation' do
+          subject.destroy
+          expect(subject).to be_destroyed
+          expect(subject.errors).to be_empty
+        end
+      end
+    end
+
+    context 'with a user that is a collection manager' do
+      let(:permission_template_access) { Hyrax::PermissionTemplateAccess.create!(permission_template: collection.permission_template, agent_type: 'user', agent_id: 'agent_id', access: Hyrax::PermissionTemplateAccess::MANAGE) }
+
+      subject { permission_template_access }
+
+      describe '#label' do
+        it 'returns the user label' do
+          expect(subject.label).to eq 'agent_id'
+        end
+      end
+      describe '#admin_group?' do
+        it 'returns true' do
+          expect(subject).not_to be_admin_group
+        end
+      end
+      describe '#destroy' do
+        it 'carries out the destroy operation' do
+          subject.destroy
+          expect(subject).to be_destroyed
+          expect(subject.errors).to be_empty
+        end
+      end
+    end
+  end
+end

--- a/spec/services/hyrax/collections/permissions_create_service_spec.rb
+++ b/spec/services/hyrax/collections/permissions_create_service_spec.rb
@@ -1,0 +1,74 @@
+require 'rails_helper'
+
+RSpec.describe Hyrax::Collections::PermissionsCreateService do
+  let(:collection_type) { Hyrax::CollectionType.create(title: 'Team', machine_id: 'team') }
+  let(:depositor)       { User.create(email: 'email@email.com', password: 'password') }
+  let(:collection)      { Collection.create(id: 'team', title: ['Team'], depositor: depositor.ms_id, collection_type_gid: collection_type.gid) }
+
+  before do
+    collection.create_collection_groups
+  end
+
+  describe '.create_ms_template' do
+    before do
+      described_class.create_ms_template(collection: collection)
+    end
+
+    it "creates a permission template for the collection" do
+      expect(Hyrax::PermissionTemplate.find_by_source_id(collection.id)).to be_persisted
+    end
+
+    it "creates the default permission template access entries for a team or project collection" do
+      expect(Hyrax::PermissionTemplate.find_by_source_id(collection.id).access_grants.count).to eq 5
+    end
+
+    describe 'template access grants' do
+      let(:access_grants) { collection.permission_template.access_grants }
+
+      describe 'admin group' do
+        let(:admin_access_grant) { access_grants.detect{ |grant| grant.agent_id == 'admin'} }
+
+        it 'creates an access grant for the admin group' do
+          expect(admin_access_grant.agent_type).to eq('group')
+          expect(admin_access_grant.access).to eq(Hyrax::PermissionTemplateAccess::MANAGE)
+        end
+      end
+
+      describe 'managers group' do
+        let(:managers_access_grant) { access_grants.detect{ |grant| grant.agent_id == 'team_managers'} }
+
+        it 'creates an access grant for the admin group' do
+          expect(managers_access_grant.agent_type).to eq('group')
+          expect(managers_access_grant.access).to eq(Hyrax::PermissionTemplateAccess::MANAGE)
+        end
+      end
+
+      describe 'editors group' do
+        let(:editors_access_grant) { access_grants.detect{ |grant| grant.agent_id == 'team_editors'} }
+
+        it 'creates an access grant for the admin group' do
+          expect(editors_access_grant.agent_type).to eq('group')
+          expect(editors_access_grant.access).to eq(Hyrax::PermissionTemplateAccess::EDIT_WORKS)
+        end
+      end
+
+      describe 'depositors group' do
+        let(:depositors_access_grant) { access_grants.detect{ |grant| grant.agent_id == 'team_depositors'} }
+
+        it 'creates an access grant for the admin group' do
+          expect(depositors_access_grant.agent_type).to eq('group')
+          expect(depositors_access_grant.access).to eq(Hyrax::PermissionTemplateAccess::DEPOSIT)
+        end
+      end
+
+      describe 'viewers group' do
+        let(:viewers_access_grant) { access_grants.detect{ |grant| grant.agent_id == 'team_viewers'} }
+
+        it 'creates an access grant for the admin group' do
+          expect(viewers_access_grant.agent_type).to eq('group')
+          expect(viewers_access_grant.access).to eq(Hyrax::PermissionTemplateAccess::VIEW)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/hyrax/collections/permissions_service_spec.rb
+++ b/spec/services/hyrax/collections/permissions_service_spec.rb
@@ -1,0 +1,555 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Hyrax::Collections::PermissionsService do
+  let(:user) { User.create(email: 'user@example.com', password: 'password') }
+  let(:team_collection_type) { Hyrax::CollectionType.create(title: 'Team', machine_id: 88) }
+
+  context 'collection specific methods' do
+    let(:collection)           { Collection.create(id: 'team', title: ['Team'], depositor: user.ms_id, collection_type_gid: team_collection_type.gid) }
+    let(:admin_set) { AdminSet.create(id: 'adminset_1') }
+    let(:col_permission_template) { collection.permission_template }
+    let(:as_permission_template) { Hyrax::PermissionTemplate.create(source_id: admin_set.id) }
+
+    before do
+      collection.create_collection_groups
+      Hyrax::Collections::PermissionsCreateService.create_ms_template(collection: collection)
+
+      collection.reset_access_controls!
+
+      allow(Hyrax::PermissionTemplate).to receive(:find_by!).with(source_id: collection.id).and_return(col_permission_template)
+    end
+
+    context 'when manage user' do
+      let(:manage_user) { User.create(email: 'manage@email.com', password: 'password') }
+      let(:ability)     { Ability.new(manage_user) }
+
+      before do
+        Hyrax::PermissionTemplateAccess.create(permission_template: collection.permission_template, agent_type: 'user', agent_id: manage_user.ms_id, access: Hyrax::PermissionTemplateAccess::MANAGE)
+      end
+
+      subject { described_class }
+
+      it '.can_deposit_in_collection? returns true' do
+        expect(subject.can_deposit_in_collection?(collection_id: collection.id, ability: ability)).to be true
+      end
+      it '.can_view_admin_show_for_collection? returns true' do
+        expect(subject.can_view_admin_show_for_collection?(collection_id: collection.id, ability: ability)).to be true
+      end
+    end
+
+    context 'when edit user' do
+      let(:ability)   { Ability.new(edit_user) }
+      let(:edit_user) { User.create(email: 'edit@email.com', password: 'password') }
+
+      before do
+        Hyrax::PermissionTemplateAccess.create(permission_template: collection.permission_template, agent_type: 'user', agent_id: edit_user.ms_id, access: Hyrax::PermissionTemplateAccess::EDIT_WORKS)
+      end
+
+      subject { described_class }
+
+      it '.can_deposit_in_collection? returns true' do
+        expect(subject.can_deposit_in_collection?(collection_id: collection.id, ability: ability)).to be true
+      end
+      it '.can_view_admin_show_for_collection? returns true' do
+        expect(subject.can_view_admin_show_for_collection?(collection_id: collection.id, ability: ability)).to be true
+      end
+    end
+
+    context 'when deposit user' do
+      let(:ability)      { Ability.new(deposit_user) }
+      let(:deposit_user) { User.create(email: 'deposit@email.com', password: 'password') }
+
+      before do
+        Hyrax::PermissionTemplateAccess.create(permission_template: collection.permission_template, agent_type: 'user', agent_id: deposit_user.ms_id, access: Hyrax::PermissionTemplateAccess::DEPOSIT)
+      end
+
+      subject { described_class }
+
+      it '.can_deposit_in_collection? returns true' do
+        expect(subject.can_deposit_in_collection?(collection_id: collection.id, ability: ability)).to be true
+      end
+      it '.can_view_admin_show_for_collection? returns true' do
+        expect(subject.can_view_admin_show_for_collection?(collection_id: collection.id, ability: ability)).to be true
+      end
+    end
+
+    context 'when view user' do
+      let(:ability)   { Ability.new(view_user) }
+      let(:view_user) { User.create(email: 'view@email.com', password: 'password') }
+
+      before do
+        Hyrax::PermissionTemplateAccess.create!(permission_template: collection.permission_template, agent_type: 'user', agent_id: view_user.ms_id, access: Hyrax::PermissionTemplateAccess::VIEW)
+      end
+
+      subject { described_class }
+
+      it '.can_deposit_in_collection? returns false' do
+        expect(subject.can_deposit_in_collection?(collection_id: collection.id, ability: ability)).to be false
+      end
+      it '.can_view_admin_show_for_collection? returns true' do
+        expect(subject.can_view_admin_show_for_collection?(collection_id: collection.id, ability: ability)).to be true
+      end
+    end
+
+    context 'when public group deposit user' do
+      let(:deposit_user)  { User.create(email: 'deposit@email.com', password: 'password') }
+      let(:ability)       { Ability.new(deposit_user) }
+
+      context 'thru membership in public group' do
+        before do
+          allow(ability).to receive(:user_groups).and_return(['public'])
+          Hyrax::PermissionTemplateAccess.create(permission_template: collection.permission_template, agent_type: 'group', agent_id: 'public', access: Hyrax::PermissionTemplateAccess::DEPOSIT)
+        end
+
+        subject { described_class }
+
+        it '.can_deposit_in_collection? returns true' do
+          expect(subject.can_deposit_in_collection?(collection_id: collection.id, ability: ability)).to be true
+        end
+        it '.can_view_admin_show_for_collection? returns false' do
+          expect(subject.can_view_admin_show_for_collection?(collection_id: collection.id, ability: ability)).to be false
+        end
+      end
+
+      context 'thru membership in registered group' do
+        before do
+          allow(ability).to receive(:user_groups).and_return(['registered'])
+          Hyrax::PermissionTemplateAccess.create(permission_template: collection.permission_template, agent_type: 'group', agent_id: 'registered', access: Hyrax::PermissionTemplateAccess::DEPOSIT)
+        end
+
+        subject { described_class }
+
+        it '.can_deposit_in_collection? returns true' do
+          expect(subject.can_deposit_in_collection?(collection_id: collection.id, ability: ability)).to be true
+        end
+        it '.can_view_admin_show_for_collection? returns false' do
+          expect(subject.can_view_admin_show_for_collection?(collection_id: collection.id, ability: ability)).to be false
+        end
+      end
+    end
+
+    context 'when public group view user' do
+      let(:view_user) { User.create(email: 'view@email.com', password: 'password') }
+      let(:ability)   { Ability.new(view_user) }
+
+      context 'thru membership in public group' do
+        before do
+          allow(ability).to receive(:user_groups).and_return(['public'])
+          Hyrax::PermissionTemplateAccess.create(permission_template: collection.permission_template, agent_type: 'group', agent_id: 'public', access: Hyrax::PermissionTemplateAccess::VIEW)
+        end
+
+        subject { described_class }
+
+        it '.can_deposit_in_collection? returns false' do
+          expect(subject.can_deposit_in_collection?(collection_id: collection.id, ability: ability)).to be false
+        end
+        it '.can_view_admin_show_for_collection? returns false' do
+          expect(subject.can_view_admin_show_for_collection?(collection_id: collection.id, ability: ability)).to be false
+        end
+      end
+
+      context 'thru membership in registered group' do
+        before do
+          allow(ability).to receive(:user_groups).and_return(['registered'])
+          Hyrax::PermissionTemplateAccess.create(permission_template: collection.permission_template, agent_type: 'group', agent_id: 'registered', access: Hyrax::PermissionTemplateAccess::VIEW)
+        end
+
+        subject { described_class }
+
+        it '.can_deposit_in_collection? returns false' do
+          expect(subject.can_deposit_in_collection?(collection_id: collection.id, ability: ability)).to be false
+        end
+        it '.can_view_admin_show_for_collection? returns false' do
+          expect(subject.can_view_admin_show_for_collection?(collection_id: collection.id, ability: ability)).to be false
+        end
+      end
+    end
+
+    context 'when user without access' do
+      let(:no_access_user) { User.create(email: 'noaccess@email.com', password: 'password') }
+      let(:ability)   { Ability.new(no_access_user) }
+
+      before do
+        allow(ability).to receive(:user_groups).and_return([])
+      end
+
+      subject { described_class }
+
+      it '.can_deposit_in_collection? returns false' do
+        expect(subject.can_deposit_in_collection?(collection_id: collection.id, ability: ability)).to be false
+      end
+      it '.can_view_admin_show_for_collection? returns false' do
+        expect(subject.can_view_admin_show_for_collection?(collection_id: collection.id, ability: ability)).to be false
+      end
+    end
+  end
+
+  context 'methods returning ids' do
+    let(:ability)     { Ability.new(user) }
+    let(:user2)       { User.create(email: 'user2@email.com', password: 'password') }
+
+    let(:collection)  { Collection.create(id: 'col1', title: ['collection 1'], depositor: user2.ms_id, collection_type_gid: team_collection_type.gid) }
+
+    let(:collection2) { Collection.create(id: 'col2', title: ['collection 2'], depositor: user2.ms_id, collection_type_gid: team_collection_type.gid) }
+    let(:collection3) { Collection.create(id: 'col3', title: ['collection 3'], depositor: user2.ms_id, collection_type_gid: team_collection_type.gid) }
+    let(:collections) { [collection, collection2, collection3] }
+
+    before do
+      collections.each do |collection|
+        collection.create_collection_groups
+        Hyrax::Collections::PermissionsCreateService.create_ms_template(collection: collection)
+        collection.reset_access_controls!
+      end
+    end
+
+    describe '.collection_ids_for_user' do
+      describe 'manage access' do
+        before do
+          collection.managers << user
+          collection.managers_group.save
+          collection.managers_group.reload
+
+          Hyrax::PermissionTemplateAccess.create(permission_template: collection2.permission_template, agent_type: 'user', agent_id: user.ms_id, access: Hyrax::PermissionTemplateAccess::MANAGE)
+        end
+        it 'returns collection ids where user has manage access' do
+          expect(described_class.collection_ids_for_user(access: 'manage', ability: ability)).to match_array [collection.id, collection2.id]
+        end
+      end
+
+      describe 'edit works access' do
+        before do
+          collection.editors << user
+          collection.editors_group.save
+          collection.editors_group.reload
+
+          Hyrax::PermissionTemplateAccess.create(permission_template: collection3.permission_template, agent_type: 'user', agent_id: user.ms_id, access: Hyrax::PermissionTemplateAccess::EDIT_WORKS)
+        end
+        it 'returns collection ids where user has deposit access' do
+          expect(described_class.collection_ids_for_user(access: 'edit_works', ability: ability)).to match_array [collection.id, collection3.id]
+        end
+      end
+
+      describe 'deposit access' do
+        before do
+          collection.depositors << user
+          collection.depositors_group.save
+          collection.depositors_group.reload
+
+          Hyrax::PermissionTemplateAccess.create(permission_template: collection2.permission_template, agent_type: 'user', agent_id: user.ms_id, access: Hyrax::PermissionTemplateAccess::DEPOSIT)
+        end
+        it 'returns collection ids where user has deposit access' do
+          expect(described_class.collection_ids_for_user(access: 'deposit', ability: ability)).to match_array [collection.id, collection2.id]
+        end
+      end
+
+      describe 'view access' do
+        before do
+          collection.viewers << user
+          collection.viewers_group.save
+          collection.viewers_group.reload
+
+          Hyrax::PermissionTemplateAccess.create(permission_template: collection2.permission_template, agent_type: 'user', agent_id: user.ms_id, access: Hyrax::PermissionTemplateAccess::VIEW)
+        end
+        it 'returns collection ids where user has view access' do
+          expect(described_class.collection_ids_for_user(access: 'view', ability: ability)).to match_array [collection.id, collection2.id]
+        end
+      end
+
+      describe 'all access levels' do
+        let(:collection4) { Collection.create(id: 'col4', title: ['collection 4'], depositor: user2.ms_id, collection_type_gid: team_collection_type.gid) }
+
+        before do
+          collection4.create_collection_groups
+          Hyrax::Collections::PermissionsCreateService.create_ms_template(collection: collection4)
+          collection4.reset_access_controls!
+
+          collection.managers << user
+          collection.managers_group.save
+          collection.managers_group.reload
+
+          collection2.editors << user
+          collection2.editors_group.save
+          collection2.editors_group.reload
+
+          Hyrax::PermissionTemplateAccess.create(permission_template: collection3.permission_template, agent_type: 'user', agent_id: user.ms_id, access: Hyrax::PermissionTemplateAccess::DEPOSIT)
+
+          Hyrax::PermissionTemplateAccess.create(permission_template: collection4.permission_template, agent_type: 'user', agent_id: user.ms_id, access: Hyrax::PermissionTemplateAccess::VIEW)
+        end
+
+        it 'returns collection ids where user has manage, deposit, or view access' do
+          all = [collection.id, collection2.id, collection3.id, collection4.id]
+          expect(described_class.collection_ids_for_user(access: ['manage', 'edit_works', 'deposit', 'view'], ability: ability)).to match_array all
+        end
+      end
+
+      context 'when user has no access' do
+        let(:ability) { Ability.new(user) }
+
+        it 'returns empty array' do
+          expect(described_class.collection_ids_for_user(access: ['manage', 'deposit', 'view'], ability: ability)).to match_array []
+        end
+      end
+    end
+
+    describe '.source_ids_for_manage' do
+      let(:admin_set)  { AdminSet.create(title: ['admin set 1']) }
+
+      before do
+        Hyrax::PermissionTemplate.create(source_id: admin_set.id)
+      end
+
+      context 'user manages collection and admin set' do
+        before do
+          collection.managers << user
+          collection.managers_group.save
+          collection.managers_group.reload
+
+          Hyrax::PermissionTemplateAccess.create(permission_template: admin_set.permission_template, agent_type: 'user', agent_id: user.ms_id, access: Hyrax::PermissionTemplateAccess::MANAGE)
+        end
+
+        it 'returns collection and admin set ids where user has manage access' do
+          expect(described_class.source_ids_for_manage(ability: ability)).to match_array [collection.id, admin_set.id]
+        end
+        it 'returns collection ids where user has manage access' do
+          expect(described_class.source_ids_for_manage(ability: ability, source_type: 'collection')).to match_array [collection.id]
+        end
+        it 'returns admin set ids where user has manage access' do
+          expect(described_class.source_ids_for_manage(ability: ability, source_type: 'admin_set')).to match_array [admin_set.id]
+        end
+      end
+
+      context 'when user has no access' do
+        let(:ability) { Ability.new(user) }
+
+        it 'returns empty array' do
+          expect(described_class.source_ids_for_manage(ability: ability)).to match_array []
+        end
+      end
+    end
+
+    describe '.source_ids_for_deposit' do
+      let(:admin_set)  { AdminSet.create(title: ['admin set 1']) }
+      let(:admin_set2) { AdminSet.create(title: ['admin set 2']) }
+
+      before do
+        Hyrax::PermissionTemplate.create(source_id: admin_set.id)
+        Hyrax::PermissionTemplate.create(source_id: admin_set2.id)
+      end
+
+      context 'user can deposit to collection and admin set' do
+        before do
+          collection.depositors << user
+          collection.depositors_group.save
+          collection.depositors_group.reload
+
+          Hyrax::PermissionTemplateAccess.create(permission_template: admin_set.permission_template, agent_type: 'user', agent_id: user.ms_id, access: Hyrax::PermissionTemplateAccess::DEPOSIT)
+
+          Hyrax::PermissionTemplateAccess.create(permission_template: admin_set2.permission_template, agent_type: 'group', agent_id: 'deposit_group', access: Hyrax::PermissionTemplateAccess::DEPOSIT)
+
+          allow(ability).to receive(:user_groups).and_return(ability.user_groups << 'deposit_group')
+        end
+
+        it 'returns collection and admin set ids where user has deposit access' do
+          expect(described_class.source_ids_for_deposit(ability: ability)).to match_array [collection.id, admin_set.id, admin_set2.id]
+        end
+        it 'returns collection ids where user has deposit access' do
+          expect(described_class.source_ids_for_deposit(ability: ability, source_type: 'collection')).to match_array [collection.id]
+        end
+        it 'returns admin set ids where user has deposit access' do
+          expect(described_class.source_ids_for_deposit(ability: ability, source_type: 'admin_set')).to match_array [admin_set.id, admin_set2.id]
+        end
+        it 'returns admin set ids where user has deposit access except excluded groups' do
+          expect(described_class.source_ids_for_deposit(ability: ability, source_type: 'admin_set', exclude_groups: ['deposit_group']))
+            .to match_array [admin_set.id]
+        end
+      end
+
+      context 'when user has no access' do
+        let(:ability) { Ability.new(user) }
+
+        it 'returns empty array' do
+          expect(described_class.source_ids_for_deposit(ability: ability)).to match_array []
+        end
+      end
+    end
+
+    describe '.collection_ids_for_edit_works' do
+      let(:collection4) { Collection.create(id: 'col4', title: ['collection 4'], depositor: user2.ms_id, collection_type_gid: team_collection_type.gid) }
+
+      context 'user has edit works access through group and individual access' do
+        before do
+          collection4.create_collection_groups
+          Hyrax::Collections::PermissionsCreateService.create_ms_template(collection: collection4)
+          collection4.reset_access_controls!
+
+          collection.editors << user
+          collection.editors_group.save
+          collection.editors_group.reload
+
+          collection2.managers << user
+          collection2.managers_group.save
+          collection2.managers_group.reload
+
+          Hyrax::PermissionTemplateAccess.create(permission_template: collection3.permission_template, agent_type: 'user', agent_id: user.ms_id, access: Hyrax::PermissionTemplateAccess::MANAGE)
+
+          Hyrax::PermissionTemplateAccess.create(permission_template: collection4.permission_template, agent_type: 'user', agent_id: user.ms_id, access: Hyrax::PermissionTemplateAccess::EDIT_WORKS)
+        end
+
+        it 'returns collection ids where user has edit works access' do
+          expect(described_class.collection_ids_for_edit_works(ability: ability)).to match_array [collection.id, collection2.id, collection3.id, collection4.id]
+        end
+      end
+
+      context 'when user has no access' do
+        let(:ability) { Ability.new(user) }
+
+        it 'returns empty array' do
+          expect(described_class.collection_ids_for_edit_works(ability: ability)).to match_array []
+        end
+      end
+    end
+
+    describe '.collection_ids_for_deposit' do
+      context 'user has deposit access through group and individual access' do
+        before do
+          collection.depositors << user
+          collection.depositors_group.save
+          collection.depositors_group.reload
+
+          Hyrax::PermissionTemplateAccess.create(permission_template: collection2.permission_template, agent_type: 'user', agent_id: user.ms_id, access: Hyrax::PermissionTemplateAccess::DEPOSIT)
+        end
+
+        it 'returns collection ids where user has deposit access' do
+          expect(described_class.collection_ids_for_deposit(ability: ability)).to match_array [collection.id, collection2.id]
+        end
+      end
+
+      context 'when user has no access' do
+        let(:ability) { Ability.new(user) }
+
+        it 'returns empty array' do
+          expect(described_class.collection_ids_for_deposit(ability: ability)).to match_array []
+        end
+      end
+    end
+
+    describe '.collection_ids_for_view' do
+      context 'user can view through group and individual access' do
+        before do
+          collection.viewers << user
+          collection.viewers_group.save
+          collection.viewers_group.reload
+
+          Hyrax::PermissionTemplateAccess.create(permission_template: collection2.permission_template, agent_type: 'user', agent_id: user.ms_id, access: Hyrax::PermissionTemplateAccess::VIEW)
+        end
+        it 'returns collection ids where user has view access' do
+          expect(described_class.collection_ids_for_view(ability: ability)).to match_array [collection.id, collection2.id]
+        end
+      end
+
+      context 'when user has no access' do
+        let(:ability) { Ability.new(user) }
+
+        it 'returns empty array' do
+          expect(described_class.collection_ids_for_view(ability: ability)).to match_array []
+        end
+      end
+    end
+
+    describe '.can_manage_any_collection?' do
+      context 'user has manage access' do
+        before do
+          collection.managers << user
+          collection.managers_group.save
+          collection.managers_group.reload
+        end
+        it 'returns true when user has manage access to at least one collection' do
+          expect(described_class.can_manage_any_collection?(ability: ability)).to be true
+        end
+      end
+
+      context 'when user has no access' do
+        let(:ability) { Ability.new(user) }
+
+        it 'returns false' do
+          expect(described_class.can_manage_any_collection?(ability: ability)).to be false
+        end
+      end
+    end
+
+    describe '.can_manage_any_admin_set?' do
+      let(:admin_set)  { AdminSet.create(title: ['admin set 1']) }
+
+      before do
+        Hyrax::PermissionTemplate.create(source_id: admin_set.id)
+      end
+
+      context 'user has manage access' do
+        before do
+          Hyrax::PermissionTemplateAccess.create(permission_template: admin_set.permission_template, agent_type: 'user', agent_id: user.ms_id, access: Hyrax::PermissionTemplateAccess::MANAGE)
+        end
+        it 'returns true when user has manage access to at least one admin set' do
+          expect(described_class.can_manage_any_admin_set?(ability: ability)).to be true
+        end
+      end
+
+      context 'when user has no access' do
+        let(:ability) { Ability.new(user) }
+
+        it 'returns false' do
+          expect(described_class.can_manage_any_admin_set?(ability: ability)).to be false
+        end
+      end
+    end
+
+    describe '.can_view_admin_show_for_any_collection?' do
+      context 'user has access' do
+        before do
+          collection.editors << user
+          collection.editors_group.save
+          collection.editors_group.reload
+        end
+
+        it 'returns true when user has manage, deposit, edit works, or view access to at least one collection' do
+          expect(described_class.can_view_admin_show_for_any_collection?(ability: ability)).to be true
+        end
+      end
+
+      context 'when user has no access' do
+        let(:ability) { Ability.new(user) }
+
+        it 'returns false' do
+          expect(described_class.can_view_admin_show_for_any_collection?(ability: ability)).to be false
+        end
+      end
+    end
+
+    describe '.can_view_admin_show_for_any_admin set?' do
+      let(:admin_set)  { AdminSet.create(title: ['admin set 1']) }
+
+      before do
+        Hyrax::PermissionTemplate.create(source_id: admin_set.id)
+      end
+
+      context 'user has access' do
+        before do
+            Hyrax::PermissionTemplateAccess.create(permission_template: admin_set.permission_template, agent_type: 'user', agent_id: user.ms_id, access: Hyrax::PermissionTemplateAccess::VIEW)
+        end
+
+        it 'returns true when user has manage, deposit, or view access to at least one admin set' do
+          expect(described_class.can_view_admin_show_for_any_admin_set?(ability: ability)).to be true
+        end
+      end
+
+      context 'when user has no access' do
+        let(:ability) { Ability.new(user) }
+
+        it 'returns false' do
+          expect(described_class.can_view_admin_show_for_any_admin_set?(ability: ability)).to be false
+        end
+      end
+    end
+  end
+end

--- a/spec/services/hyrax/permission_template_applicator_spec.rb
+++ b/spec/services/hyrax/permission_template_applicator_spec.rb
@@ -1,0 +1,81 @@
+require 'rails_helper'
+
+RSpec.describe Hyrax::PermissionTemplateApplicator do
+  subject(:applicator) { described_class.new(template: template) }
+  let(:manage_groups)  { ['managers_group'] }
+  let(:manage_users)   { ['manage_user'] }
+  let(:work_editor_groups)  { ['editors_group'] }
+  let(:view_groups)    { ['viewers_group'] }
+  let(:view_users)     { ['view_user'] }
+  let(:work)           { Media.create(title: ['media']) }
+
+  describe '.apply' do
+    let(:template)       { :not_a_template }
+
+    it 'initializes with template' do
+      expect(described_class.apply(template))
+        .to have_attributes(template: template)
+    end
+  end
+
+  describe '#apply_to' do
+    let(:template) { Hyrax::PermissionTemplate.create() }
+
+    before do
+      # groups
+      Hyrax::PermissionTemplateAccess.create(permission_template: template, agent_type: 'group', agent_id: 'managers_group', access: Hyrax::PermissionTemplateAccess::MANAGE)
+      Hyrax::PermissionTemplateAccess.create(permission_template: template, agent_type: 'group', agent_id: 'editors_group', access: Hyrax::PermissionTemplateAccess::EDIT_WORKS)
+      Hyrax::PermissionTemplateAccess.create(permission_template: template, agent_type: 'group', agent_id: 'viewers_group', access: Hyrax::PermissionTemplateAccess::VIEW)
+
+      # users
+      Hyrax::PermissionTemplateAccess.create(permission_template: template, agent_type: 'user', agent_id: 'manage_user', access: Hyrax::PermissionTemplateAccess::MANAGE)
+      Hyrax::PermissionTemplateAccess.create(permission_template: template, agent_type: 'user', agent_id: 'view_user', access: Hyrax::PermissionTemplateAccess::VIEW)
+
+    end
+
+    # adds both manage and edit_works access groups as work editors
+    it 'applies edit groups' do
+      edit_after_application = work.edit_groups + manage_groups + work_editor_groups
+
+      expect { applicator.apply_to(model: work) }
+        .to change { work.edit_groups }
+        .to contain_exactly(*edit_after_application)
+    end
+
+    it 'applies edit users' do
+      edit_after_application = work.edit_users + manage_users
+
+      expect { applicator.apply_to(model: work) }
+        .to change { work.edit_users }
+        .to contain_exactly(*edit_after_application)
+    end
+
+    it 'applies read groups' do
+      read_after_application = work.read_groups + view_groups
+
+      expect { applicator.apply_to(model: work) }
+        .to change { work.read_groups }
+        .to contain_exactly(*read_after_application)
+    end
+
+    it 'applies read users' do
+      read_after_application = work.read_users + view_users
+
+      expect { applicator.apply_to(model: work) }
+        .to change { work.read_users }
+        .to contain_exactly(*read_after_application)
+    end
+  end
+
+  describe '#template' do
+    let(:template)     { :not_a_template }
+    let(:new_template) { :not_another_template }
+
+    it 'has a template attribute' do
+      expect { applicator.template = new_template }
+        .to change { applicator.template }
+        .from(template)
+        .to new_template
+    end
+  end
+end


### PR DESCRIPTION
Adds a new 'editors' user group to teams and projects where group members cannot edit team/project metadata and settings, but do have access to edit all works created through the team/project. 